### PR TITLE
feat(api): build CRUD endpoints for RCA management

### DIFF
--- a/app/rca_models.py
+++ b/app/rca_models.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, Field
+from typing import List
+import datetime
+
+class TimelineEvent(BaseModel):
+    timestamp: datetime.datetime
+    description: str
+
+class RcaModel(BaseModel):
+    ticket_id: str
+    author: str
+    summary: str
+    timeline: List[TimelineEvent]
+    root_cause: str
+    resolution: str
+    corrective_actions: List[str]

--- a/app/rca_routes.py
+++ b/app/rca_routes.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, HTTPException, status
+from typing import Dict
+from .rca_models import RcaModel 
+
+
+router = APIRouter(
+    prefix="/rca",
+    tags=["RCA Management"]
+)
+
+
+db: Dict[str, RcaModel] = {}
+
+@router.post("/{ticket_id}", status_code=status.HTTP_201_CREATED, response_model=RcaModel)
+def create_rca(ticket_id: str, rca: RcaModel):
+    if ticket_id in db:
+        raise HTTPException(status_code=409, detail="RCA already exists.")
+    db[ticket_id] = rca
+    return rca
+
+@router.get("/{ticket_id}", response_model=RcaModel)
+def get_rca(ticket_id: str):
+    if ticket_id not in db:
+        raise HTTPException(status_code=404, detail="RCA not found.")
+    return db[ticket_id]
+
+@router.put("/{ticket_id}", response_model=RcaModel)
+def update_rca(ticket_id: str, rca: RcaModel):
+    if ticket_id not in db:
+        raise HTTPException(status_code=404, detail="RCA not found.")
+    db[ticket_id] = rca
+    return rca

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel, Field
 from typing import List, Dict
 from datetime import datetime
 import operator
@@ -13,10 +13,27 @@ class ReportVersion(BaseModel):
     content: str
     timestamp: datetime
 
-# --- Mock Database ---
-# In a real application, this data would come from a database like PostgreSQL or MongoDB.
-# The key is the ticket_id. The value is a list of report versions.
-MOCK_DB: Dict[str, List[ReportVersion]] = {
+# --- NEW: Pydantic Models for RCA ---
+
+class TimelineEvent(BaseModel):
+    """Defines a single event in an incident timeline."""
+    timestamp: datetime = Field(..., example="2025-10-26T10:00:00Z")
+    description: str = Field(..., example="Initial alert received from monitoring system.")
+
+class RcaModel(BaseModel):
+    """Defines the structure for a Root Cause Analysis document."""
+    ticket_id: str = Field(..., example="OUTAGE-20251026-001")
+    author: str = Field(..., example="dev-team@example.com")
+    summary: str = Field(..., example="A brief summary of the incident and its impact.")
+    timeline: List[TimelineEvent]
+    root_cause: str = Field(..., example="A misconfiguration in the load balancer led to traffic being routed incorrectly.")
+    resolution: str = Field(..., example="The load balancer configuration was corrected and deployed.")
+    corrective_actions: List[str] = Field(..., example=["Review all load balancer configurations.", "Add automated checks for deployment pipelines."])
+
+# --- Mock Databases ---
+
+# Existing DB for outage reports
+REPORTS_DB: Dict[str, List[ReportVersion]] = {
     "TICKET-123": [
         ReportVersion(version=1, author="Alice", content="Initial report: network is down.", timestamp=datetime(2025, 10, 1, 10, 0, 0)),
         ReportVersion(version=2, author="Bob", content="Update: Issue isolated to router R-5.", timestamp=datetime(2025, 10, 1, 10, 30, 0)),
@@ -27,17 +44,19 @@ MOCK_DB: Dict[str, List[ReportVersion]] = {
     ],
 }
 
+# NEW: In-memory DB for RCA documents
+RCA_DB: Dict[str, RcaModel] = {}
+
 # --- Service Logic ---
 
 def get_report_history(ticket_id: str) -> List[ReportVersion]:
     """
     Retrieves and sorts the history for a given ticket_id.
     """
-    if ticket_id not in MOCK_DB:
+    if ticket_id not in REPORTS_DB:
         raise HTTPException(status_code=404, detail=f"No history found for ticket ID: {ticket_id}")
     
-    # Retrieve the history and sort it by version number in descending order
-    history = MOCK_DB[ticket_id]
+    history = REPORTS_DB[ticket_id]
     history.sort(key=operator.attrgetter('version'), reverse=True)
     
     return history
@@ -45,9 +64,11 @@ def get_report_history(ticket_id: str) -> List[ReportVersion]:
 # --- FastAPI Application ---
 
 app = FastAPI(
-    title="Outage Reporting API",
-    description="An API for managing and viewing outage reports.",
+    title="Outage Reporting & RCA API",
+    description="An API for managing outage reports and their corresponding Root Cause Analyses.",
 )
+
+# --- Report Endpoints ---
 
 @app.get(
     "/outages/{ticket_id}/history",
@@ -61,3 +82,69 @@ def fetch_report_history(ticket_id: str):
     sorted with the newest version first.
     """
     return get_report_history(ticket_id)
+
+# --- NEW: RCA Management Endpoints ---
+
+@app.post(
+    "/rca/{ticket_id}",
+    status_code=status.HTTP_201_CREATED,
+    response_model=RcaModel,
+    summary="Create a new RCA for an outage ticket",
+    tags=["RCA Management"],
+)
+def create_rca(ticket_id: str, rca: RcaModel):
+    """
+    Create a new Root Cause Analysis (RCA) entry for a specific outage ticket.
+    """
+    if ticket_id in RCA_DB:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"RCA for ticket ID '{ticket_id}' already exists."
+        )
+    if ticket_id != rca.ticket_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The ticket ID in the URL must match the ticket_id in the request body."
+        )
+    RCA_DB[ticket_id] = rca
+    return rca
+
+@app.get(
+    "/rca/{ticket_id}",
+    response_model=RcaModel,
+    summary="Retrieve an existing RCA",
+    tags=["RCA Management"],
+)
+def get_rca(ticket_id: str):
+    """
+    Retrieve an existing RCA by its outage ticket ID.
+    """
+    if ticket_id not in RCA_DB:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"RCA for ticket ID '{ticket_id}' not found."
+        )
+    return RCA_DB[ticket_id]
+
+@app.put(
+    "/rca/{ticket_id}",
+    response_model=RcaModel,
+    summary="Update an existing RCA",
+    tags=["RCA Management"],
+)
+def update_rca(ticket_id: str, rca: RcaModel):
+    """
+    Update an existing RCA. The entire RCA object must be provided.
+    """
+    if ticket_id not in RCA_DB:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"RCA for ticket ID '{ticket_id}' not found."
+        )
+    if ticket_id != rca.ticket_id:
+         raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The ticket ID in the URL must match the ticket_id in the request body."
+        )
+    RCA_DB[ticket_id] = rca
+    return rca


### PR DESCRIPTION
This PR adds a new set of endpoints to the `API` for creating, reading, and updating Root Cause Analysis (RCA) entries. This functionality is essential for our incident management process, allowing teams to document post-mortems for outage reports.

**Key Changes:**
- Pydantic Model (RcaModel): A new RcaModel has been defined to ensure that all RCA entries are structured correctly, with validated fields for the incident timeline, root cause analysis, and corrective actions.
- CRUD Operations: The following endpoints have been implemented:
- Create (`POST /rca/{ticket_id}`): Allows for the submission of a new RCA document tied to a specific outage ticket ID.
- Read (`GET /rca/{ticket_id}`): Retrieves the details of an existing RCA.
- Update (`PUT /rca/{ticket_id}`): Allows for the modification of an RCA after it has been created.

Closes #15 