### PR TITLE
Test/outage endpoints integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,67 +1,192 @@
-from fastapi.testclient import TestClient
-from .main import app, MOCK_DB, ReportVersion # Import the app and mock DB
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel, Field
+from typing import List, Dict
 from datetime import datetime
+import operator
 
-client = TestClient(app)
+# --- Pydantic Models (Data Shape) ---
 
-# This is a sample report that will be used across tests
-TICKET_ID_FOR_TESTS = "TICKET-789"
+class ReportVersion(BaseModel):
+    """Defines the structure of a single version of a report."""
+    version: int
+    author: str
+    content: str
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
 
-def setup_function():
-    """Pytest hook to run before each test function."""
-    # Ensure a clean slate for tests that modify the DB
-    if TICKET_ID_FOR_TESTS in MOCK_DB:
-        del MOCK_DB[TICKET_ID_FOR_TESTS]
+# --- NEW: Pydantic Models for Report Creation/Update ---
+class CreateReportPayload(BaseModel):
+    """Payload for creating a new report."""
+    ticket_id: str
+    author: str
+    content: str
 
-def test_create_report():
-    """Tests the successful creation of a new report."""
-    response = client.post(
-        "/outages",
-        json={
-            "ticket_id": TICKET_ID_FOR_TESTS,
-            "author": "Test Author",
-            "content": "This is a test report.",
-        },
-    )
-    assert response.status_code == 201
-    data = response.json()
-    assert data["version"] == 1
-    assert data["author"] == "Test Author"
-    assert data["content"] == "This is a test report."
-    # Verify it was added to our mock DB
-    assert TICKET_ID_FOR_TESTS in MOCK_DB
-    assert len(MOCK_DB[TICKET_ID_FOR_TESTS]) == 1
+class UpdateReportPayload(BaseModel):
+    """Payload for updating an existing report."""
+    author: str
+    content: str
 
-def test_update_report_version():
-    """Tests updating a report to create a second version."""
-    # First, create a report to update
-    MOCK_DB[TICKET_ID_FOR_TESTS] = [ReportVersion(version=1, author="Initial", content="First version.", timestamp=datetime.utcnow())]
+# --- Pydantic Models for RCA ---
+
+class TimelineEvent(BaseModel):
+    """Defines a single event in an incident timeline."""
+    timestamp: datetime = Field(..., example="2025-10-26T10:00:00Z")
+    description: str = Field(..., example="Initial alert received from monitoring system.")
+
+class RcaModel(BaseModel):
+    """Defines the structure for a Root Cause Analysis document."""
+    ticket_id: str = Field(..., example="OUTAGE-20251026-001")
+    author: str = Field(..., example="dev-team@example.com")
+    summary: str = Field(..., example="A brief summary of the incident and its impact.")
+    timeline: List[TimelineEvent]
+    root_cause: str = Field(..., example="A misconfiguration in the load balancer led to traffic being routed incorrectly.")
+    resolution: str = Field(..., example="The load balancer configuration was corrected and deployed.")
+    corrective_actions: List[str] = Field(..., example=["Review all load balancer configurations.", "Add automated checks for deployment pipelines."])
+
+# --- Mock Databases ---
+
+# Existing DB for outage reports
+REPORTS_DB: Dict[str, List[ReportVersion]] = {
+    "TICKET-123": [
+        ReportVersion(version=1, author="Alice", content="Initial report: network is down.", timestamp=datetime(2025, 10, 1, 10, 0, 0)),
+        ReportVersion(version=2, author="Bob", content="Update: Issue isolated to router R-5.", timestamp=datetime(2025, 10, 1, 10, 30, 0)),
+        ReportVersion(version=3, author="Alice", content="Update: Router rebooted, monitoring status.", timestamp=datetime(2025, 10, 1, 11, 0, 0)),
+    ],
+    "TICKET-456": [
+        ReportVersion(version=1, author="Charlie", content="Database CPU is at 100%.", timestamp=datetime(2025, 10, 2, 14, 0, 0)),
+    ],
+}
+
+# In-memory DB for RCA documents
+RCA_DB: Dict[str, RcaModel] = {}
+
+# --- FastAPI Application ---
+
+app = FastAPI(
+    title="Outage Reporting & RCA API",
+    description="An API for managing outage reports and their corresponding Root Cause Analyses.",
+)
+
+# --- Report Endpoints ---
+
+@app.post(
+    "/outages",
+    response_model=ReportVersion,
+    status_code=201,
+    summary="Create a new outage report",
+    tags=["Reports"],
+)
+def create_report(payload: CreateReportPayload):
+    """Creates the first version of a new outage report."""
+    if payload.ticket_id in REPORTS_DB:
+        raise HTTPException(status_code=409, detail=f"Ticket ID '{payload.ticket_id}' already exists.")
     
-    response = client.patch(
-        f"/outages/{TICKET_ID_FOR_TESTS}",
-        json={"author": "Updater", "content": "This is version 2."},
-    )
-    assert response.status_code == 200
-    data = response.json()
-    assert data["version"] == 2
-    assert data["author"] == "Updater"
-    # Verify the history now has two versions
-    assert len(MOCK_DB[TICKET_ID_FOR_TESTS]) == 2
+    new_report = ReportVersion(version=1, author=payload.author, content=payload.content)
+    REPORTS_DB[payload.ticket_id] = [new_report]
+    return new_report
 
-def test_get_report_history():
-    """Tests retrieving the sorted history of a multi-version report."""
-    response = client.get("/outages/TICKET-123/history")
+@app.patch(
+    "/outages/{ticket_id}",
+    response_model=ReportVersion,
+    summary="Update an outage report with a new version",
+    tags=["Reports"],
+)
+def update_report(ticket_id: str, payload: UpdateReportPayload):
+    """Adds a new version to an existing outage report."""
+    if ticket_id not in REPORTS_DB:
+        raise HTTPException(status_code=404, detail=f"No report found for ticket ID: {ticket_id}")
     
-    assert response.status_code == 200
-    history = response.json()
-    assert len(history) == 3
-    # Check that it's sorted with the newest version first
-    assert history[0]["version"] == 3
-    assert history[1]["version"] == 2
-    assert history[2]["version"] == 1
+    current_history = REPORTS_DB[ticket_id]
+    # Find the latest version number correctly, even if the list is not sorted
+    next_version_number = max(v.version for v in current_history) + 1
+    
+    new_version = ReportVersion(
+        version=next_version_number,
+        author=payload.author,
+        content=payload.content,
+    )
+    current_history.append(new_version)
+    return new_version
 
-def test_get_history_for_nonexistent_ticket():
-    """Tests that a 404 is returned for a ticket that doesn't exist."""
-    response = client.get("/outages/TICKET-DOES-NOT-EXIST/history")
-    assert response.status_code == 404
-    assert response.json() == {"detail": "No history found for ticket ID: TICKET-DOES-NOT-EXIST"}
+@app.get(
+    "/outages/{ticket_id}/history",
+    response_model=List[ReportVersion],
+    summary="Retrieve the full version history of a report",
+    tags=["Reports"],
+)
+def fetch_report_history(ticket_id: str):
+    """
+    Retrieves all versions of a report for a specific `ticket_id`,
+    sorted with the newest version first.
+    """
+    if ticket_id not in REPORTS_DB:
+        raise HTTPException(status_code=404, detail=f"No history found for ticket ID: {ticket_id}")
+    
+    history = REPORTS_DB[ticket_id]
+    # Return a sorted copy, don't sort the DB in place to avoid side effects
+    return sorted(history, key=operator.attrgetter('version'), reverse=True)
+
+# --- RCA Management Endpoints ---
+
+@app.post(
+    "/rca/{ticket_id}",
+    status_code=status.HTTP_201_CREATED,
+    response_model=RcaModel,
+    summary="Create a new RCA for an outage ticket",
+    tags=["RCA Management"],
+)
+def create_rca(ticket_id: str, rca: RcaModel):
+    """
+    Create a new Root Cause Analysis (RCA) entry for a specific outage ticket.
+    """
+    if ticket_id in RCA_DB:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"RCA for ticket ID '{ticket_id}' already exists."
+        )
+    if ticket_id != rca.ticket_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The ticket ID in the URL must match the ticket_id in the request body."
+        )
+    RCA_DB[ticket_id] = rca
+    return rca
+
+@app.get(
+    "/rca/{ticket_id}",
+    response_model=RcaModel,
+    summary="Retrieve an existing RCA",
+    tags=["RCA Management"],
+)
+def get_rca(ticket_id: str):
+    """
+    Retrieve an existing RCA by its outage ticket ID.
+    """
+    if ticket_id not in RCA_DB:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"RCA for ticket ID '{ticket_id}' not found."
+        )
+    return RCA_DB[ticket_id]
+
+@app.put(
+    "/rca/{ticket_id}",
+    response_model=RcaModel,
+    summary="Update an existing RCA",
+    tags=["RCA Management"],
+)
+def update_rca(ticket_id: str, rca: RcaModel):
+    """
+    Update an existing RCA. The entire RCA object must be provided.
+    """
+    if ticket_id not in RCA_DB:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"RCA for ticket ID '{ticket_id}' not found."
+        )
+    if ticket_id != rca.ticket_id:
+         raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="The ticket ID in the URL must match the ticket_id in the request body."
+        )
+    RCA_DB[ticket_id] = rca
+    return rca

--- a/main.py
+++ b/main.py
@@ -1,192 +1,67 @@
-from fastapi import FastAPI, HTTPException, status
-from pydantic import BaseModel, Field
-from typing import List, Dict
+from fastapi.testclient import TestClient
+from .main import app, MOCK_DB, ReportVersion # Import the app and mock DB
 from datetime import datetime
-import operator
 
-# --- Pydantic Models (Data Shape) ---
+client = TestClient(app)
 
-class ReportVersion(BaseModel):
-    """Defines the structure of a single version of a report."""
-    version: int
-    author: str
-    content: str
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+# This is a sample report that will be used across tests
+TICKET_ID_FOR_TESTS = "TICKET-789"
 
-# --- NEW: Pydantic Models for Report Creation/Update ---
-class CreateReportPayload(BaseModel):
-    """Payload for creating a new report."""
-    ticket_id: str
-    author: str
-    content: str
+def setup_function():
+    """Pytest hook to run before each test function."""
+    # Ensure a clean slate for tests that modify the DB
+    if TICKET_ID_FOR_TESTS in MOCK_DB:
+        del MOCK_DB[TICKET_ID_FOR_TESTS]
 
-class UpdateReportPayload(BaseModel):
-    """Payload for updating an existing report."""
-    author: str
-    content: str
-
-# --- Pydantic Models for RCA ---
-
-class TimelineEvent(BaseModel):
-    """Defines a single event in an incident timeline."""
-    timestamp: datetime = Field(..., example="2025-10-26T10:00:00Z")
-    description: str = Field(..., example="Initial alert received from monitoring system.")
-
-class RcaModel(BaseModel):
-    """Defines the structure for a Root Cause Analysis document."""
-    ticket_id: str = Field(..., example="OUTAGE-20251026-001")
-    author: str = Field(..., example="dev-team@example.com")
-    summary: str = Field(..., example="A brief summary of the incident and its impact.")
-    timeline: List[TimelineEvent]
-    root_cause: str = Field(..., example="A misconfiguration in the load balancer led to traffic being routed incorrectly.")
-    resolution: str = Field(..., example="The load balancer configuration was corrected and deployed.")
-    corrective_actions: List[str] = Field(..., example=["Review all load balancer configurations.", "Add automated checks for deployment pipelines."])
-
-# --- Mock Databases ---
-
-# Existing DB for outage reports
-REPORTS_DB: Dict[str, List[ReportVersion]] = {
-    "TICKET-123": [
-        ReportVersion(version=1, author="Alice", content="Initial report: network is down.", timestamp=datetime(2025, 10, 1, 10, 0, 0)),
-        ReportVersion(version=2, author="Bob", content="Update: Issue isolated to router R-5.", timestamp=datetime(2025, 10, 1, 10, 30, 0)),
-        ReportVersion(version=3, author="Alice", content="Update: Router rebooted, monitoring status.", timestamp=datetime(2025, 10, 1, 11, 0, 0)),
-    ],
-    "TICKET-456": [
-        ReportVersion(version=1, author="Charlie", content="Database CPU is at 100%.", timestamp=datetime(2025, 10, 2, 14, 0, 0)),
-    ],
-}
-
-# In-memory DB for RCA documents
-RCA_DB: Dict[str, RcaModel] = {}
-
-# --- FastAPI Application ---
-
-app = FastAPI(
-    title="Outage Reporting & RCA API",
-    description="An API for managing outage reports and their corresponding Root Cause Analyses.",
-)
-
-# --- Report Endpoints ---
-
-@app.post(
-    "/outages",
-    response_model=ReportVersion,
-    status_code=201,
-    summary="Create a new outage report",
-    tags=["Reports"],
-)
-def create_report(payload: CreateReportPayload):
-    """Creates the first version of a new outage report."""
-    if payload.ticket_id in REPORTS_DB:
-        raise HTTPException(status_code=409, detail=f"Ticket ID '{payload.ticket_id}' already exists.")
-    
-    new_report = ReportVersion(version=1, author=payload.author, content=payload.content)
-    REPORTS_DB[payload.ticket_id] = [new_report]
-    return new_report
-
-@app.patch(
-    "/outages/{ticket_id}",
-    response_model=ReportVersion,
-    summary="Update an outage report with a new version",
-    tags=["Reports"],
-)
-def update_report(ticket_id: str, payload: UpdateReportPayload):
-    """Adds a new version to an existing outage report."""
-    if ticket_id not in REPORTS_DB:
-        raise HTTPException(status_code=404, detail=f"No report found for ticket ID: {ticket_id}")
-    
-    current_history = REPORTS_DB[ticket_id]
-    # Find the latest version number correctly, even if the list is not sorted
-    next_version_number = max(v.version for v in current_history) + 1
-    
-    new_version = ReportVersion(
-        version=next_version_number,
-        author=payload.author,
-        content=payload.content,
+def test_create_report():
+    """Tests the successful creation of a new report."""
+    response = client.post(
+        "/outages",
+        json={
+            "ticket_id": TICKET_ID_FOR_TESTS,
+            "author": "Test Author",
+            "content": "This is a test report.",
+        },
     )
-    current_history.append(new_version)
-    return new_version
+    assert response.status_code == 201
+    data = response.json()
+    assert data["version"] == 1
+    assert data["author"] == "Test Author"
+    assert data["content"] == "This is a test report."
+    # Verify it was added to our mock DB
+    assert TICKET_ID_FOR_TESTS in MOCK_DB
+    assert len(MOCK_DB[TICKET_ID_FOR_TESTS]) == 1
 
-@app.get(
-    "/outages/{ticket_id}/history",
-    response_model=List[ReportVersion],
-    summary="Retrieve the full version history of a report",
-    tags=["Reports"],
-)
-def fetch_report_history(ticket_id: str):
-    """
-    Retrieves all versions of a report for a specific `ticket_id`,
-    sorted with the newest version first.
-    """
-    if ticket_id not in REPORTS_DB:
-        raise HTTPException(status_code=404, detail=f"No history found for ticket ID: {ticket_id}")
+def test_update_report_version():
+    """Tests updating a report to create a second version."""
+    # First, create a report to update
+    MOCK_DB[TICKET_ID_FOR_TESTS] = [ReportVersion(version=1, author="Initial", content="First version.", timestamp=datetime.utcnow())]
     
-    history = REPORTS_DB[ticket_id]
-    # Return a sorted copy, don't sort the DB in place to avoid side effects
-    return sorted(history, key=operator.attrgetter('version'), reverse=True)
+    response = client.patch(
+        f"/outages/{TICKET_ID_FOR_TESTS}",
+        json={"author": "Updater", "content": "This is version 2."},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["version"] == 2
+    assert data["author"] == "Updater"
+    # Verify the history now has two versions
+    assert len(MOCK_DB[TICKET_ID_FOR_TESTS]) == 2
 
-# --- RCA Management Endpoints ---
+def test_get_report_history():
+    """Tests retrieving the sorted history of a multi-version report."""
+    response = client.get("/outages/TICKET-123/history")
+    
+    assert response.status_code == 200
+    history = response.json()
+    assert len(history) == 3
+    # Check that it's sorted with the newest version first
+    assert history[0]["version"] == 3
+    assert history[1]["version"] == 2
+    assert history[2]["version"] == 1
 
-@app.post(
-    "/rca/{ticket_id}",
-    status_code=status.HTTP_201_CREATED,
-    response_model=RcaModel,
-    summary="Create a new RCA for an outage ticket",
-    tags=["RCA Management"],
-)
-def create_rca(ticket_id: str, rca: RcaModel):
-    """
-    Create a new Root Cause Analysis (RCA) entry for a specific outage ticket.
-    """
-    if ticket_id in RCA_DB:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=f"RCA for ticket ID '{ticket_id}' already exists."
-        )
-    if ticket_id != rca.ticket_id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="The ticket ID in the URL must match the ticket_id in the request body."
-        )
-    RCA_DB[ticket_id] = rca
-    return rca
-
-@app.get(
-    "/rca/{ticket_id}",
-    response_model=RcaModel,
-    summary="Retrieve an existing RCA",
-    tags=["RCA Management"],
-)
-def get_rca(ticket_id: str):
-    """
-    Retrieve an existing RCA by its outage ticket ID.
-    """
-    if ticket_id not in RCA_DB:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"RCA for ticket ID '{ticket_id}' not found."
-        )
-    return RCA_DB[ticket_id]
-
-@app.put(
-    "/rca/{ticket_id}",
-    response_model=RcaModel,
-    summary="Update an existing RCA",
-    tags=["RCA Management"],
-)
-def update_rca(ticket_id: str, rca: RcaModel):
-    """
-    Update an existing RCA. The entire RCA object must be provided.
-    """
-    if ticket_id not in RCA_DB:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"RCA for ticket ID '{ticket_id}' not found."
-        )
-    if ticket_id != rca.ticket_id:
-         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="The ticket ID in the URL must match the ticket_id in the request body."
-        )
-    RCA_DB[ticket_id] = rca
-    return rca
+def test_get_history_for_nonexistent_ticket():
+    """Tests that a 404 is returned for a ticket that doesn't exist."""
+    response = client.get("/outages/TICKET-DOES-NOT-EXIST/history")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No history found for ticket ID: TICKET-DOES-NOT-EXIST"}

--- a/main.py
+++ b/main.py
@@ -11,21 +11,9 @@ class ReportVersion(BaseModel):
     version: int
     author: str
     content: str
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime
 
-# --- NEW: Pydantic Models for Report Creation/Update ---
-class CreateReportPayload(BaseModel):
-    """Payload for creating a new report."""
-    ticket_id: str
-    author: str
-    content: str
-
-class UpdateReportPayload(BaseModel):
-    """Payload for updating an existing report."""
-    author: str
-    content: str
-
-# --- Pydantic Models for RCA ---
+# --- NEW: Pydantic Models for RCA ---
 
 class TimelineEvent(BaseModel):
     """Defines a single event in an incident timeline."""
@@ -56,8 +44,22 @@ REPORTS_DB: Dict[str, List[ReportVersion]] = {
     ],
 }
 
-# In-memory DB for RCA documents
+# NEW: In-memory DB for RCA documents
 RCA_DB: Dict[str, RcaModel] = {}
+
+# --- Service Logic ---
+
+def get_report_history(ticket_id: str) -> List[ReportVersion]:
+    """
+    Retrieves and sorts the history for a given ticket_id.
+    """
+    if ticket_id not in REPORTS_DB:
+        raise HTTPException(status_code=404, detail=f"No history found for ticket ID: {ticket_id}")
+    
+    history = REPORTS_DB[ticket_id]
+    history.sort(key=operator.attrgetter('version'), reverse=True)
+    
+    return history
 
 # --- FastAPI Application ---
 
@@ -67,45 +69,6 @@ app = FastAPI(
 )
 
 # --- Report Endpoints ---
-
-@app.post(
-    "/outages",
-    response_model=ReportVersion,
-    status_code=201,
-    summary="Create a new outage report",
-    tags=["Reports"],
-)
-def create_report(payload: CreateReportPayload):
-    """Creates the first version of a new outage report."""
-    if payload.ticket_id in REPORTS_DB:
-        raise HTTPException(status_code=409, detail=f"Ticket ID '{payload.ticket_id}' already exists.")
-    
-    new_report = ReportVersion(version=1, author=payload.author, content=payload.content)
-    REPORTS_DB[payload.ticket_id] = [new_report]
-    return new_report
-
-@app.patch(
-    "/outages/{ticket_id}",
-    response_model=ReportVersion,
-    summary="Update an outage report with a new version",
-    tags=["Reports"],
-)
-def update_report(ticket_id: str, payload: UpdateReportPayload):
-    """Adds a new version to an existing outage report."""
-    if ticket_id not in REPORTS_DB:
-        raise HTTPException(status_code=404, detail=f"No report found for ticket ID: {ticket_id}")
-    
-    current_history = REPORTS_DB[ticket_id]
-    # Find the latest version number correctly, even if the list is not sorted
-    next_version_number = max(v.version for v in current_history) + 1
-    
-    new_version = ReportVersion(
-        version=next_version_number,
-        author=payload.author,
-        content=payload.content,
-    )
-    current_history.append(new_version)
-    return new_version
 
 @app.get(
     "/outages/{ticket_id}/history",
@@ -118,14 +81,9 @@ def fetch_report_history(ticket_id: str):
     Retrieves all versions of a report for a specific `ticket_id`,
     sorted with the newest version first.
     """
-    if ticket_id not in REPORTS_DB:
-        raise HTTPException(status_code=404, detail=f"No history found for ticket ID: {ticket_id}")
-    
-    history = REPORTS_DB[ticket_id]
-    # Return a sorted copy, don't sort the DB in place to avoid side effects
-    return sorted(history, key=operator.attrgetter('version'), reverse=True)
+    return get_report_history(ticket_id)
 
-# --- RCA Management Endpoints ---
+# --- NEW: RCA Management Endpoints ---
 
 @app.post(
     "/rca/{ticket_id}",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,67 @@
+from fastapi.testclient import TestClient
+from .main import app, MOCK_DB, ReportVersion # Import the app and mock DB
+from datetime import datetime
+
+client = TestClient(app)
+
+# This is a sample report that will be used across tests
+TICKET_ID_FOR_TESTS = "TICKET-789"
+
+def setup_function():
+    """Pytest hook to run before each test function."""
+    # Ensure a clean slate for tests that modify the DB
+    if TICKET_ID_FOR_TESTS in MOCK_DB:
+        del MOCK_DB[TICKET_ID_FOR_TESTS]
+
+def test_create_report():
+    """Tests the successful creation of a new report."""
+    response = client.post(
+        "/outages",
+        json={
+            "ticket_id": TICKET_ID_FOR_TESTS,
+            "author": "Test Author",
+            "content": "This is a test report.",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["version"] == 1
+    assert data["author"] == "Test Author"
+    assert data["content"] == "This is a test report."
+    # Verify it was added to our mock DB
+    assert TICKET_ID_FOR_TESTS in MOCK_DB
+    assert len(MOCK_DB[TICKET_ID_FOR_TESTS]) == 1
+
+def test_update_report_version():
+    """Tests updating a report to create a second version."""
+    # First, create a report to update
+    MOCK_DB[TICKET_ID_FOR_TESTS] = [ReportVersion(version=1, author="Initial", content="First version.", timestamp=datetime.utcnow())]
+    
+    response = client.patch(
+        f"/outages/{TICKET_ID_FOR_TESTS}",
+        json={"author": "Updater", "content": "This is version 2."},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["version"] == 2
+    assert data["author"] == "Updater"
+    # Verify the history now has two versions
+    assert len(MOCK_DB[TICKET_ID_FOR_TESTS]) == 2
+
+def test_get_report_history():
+    """Tests retrieving the sorted history of a multi-version report."""
+    response = client.get("/outages/TICKET-123/history")
+    
+    assert response.status_code == 200
+    history = response.json()
+    assert len(history) == 3
+    # Check that it's sorted with the newest version first
+    assert history[0]["version"] == 3
+    assert history[1]["version"] == 2
+    assert history[2]["version"] == 1
+
+def test_get_history_for_nonexistent_ticket():
+    """Tests that a 404 is returned for a ticket that doesn't exist."""
+    response = client.get("/outages/TICKET-DOES-NOT-EXIST/history")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No history found for ticket ID: TICKET-DOES-NOT-EXIST"}


### PR DESCRIPTION
# PR: test(api): Create Tests for Outage Report Endpoints

**Closes #8**

## Description

This pull request introduces a suite of integration tests for the outage reporting API endpoints. It establishes a robust testing foundation using **`pytest`** and FastAPI's **`TestClient`** to ensure the reliability and correctness of the core reporting features.

The tests cover the complete lifecycle of a report: creation, updating (versioning), and history retrieval. This provides an automated safety net to prevent regressions and validate expected behavior.

---

## Implementation Details

-   **Testing Framework**: `pytest` is used as the test runner, and `httpx` (via `TestClient`) is used to make live requests to the application in a test environment.
-   **In-Memory Test Double**: The existing in-memory dictionary (`MOCK_DB`) is used as a test double, allowing tests to run quickly and without the need for a live database connection. A `setup_function` is used to ensure a clean state before each test that modifies data.
-   **Application Updates**: The main application was updated to include the missing `POST /outages` and `PATCH /outages/{ticket_id}` endpoints, enabling a full-lifecycle test.

### Test Coverage

The following scenarios are now covered by automated tests:

-   **Report Creation**: Verifies that a `POST` request to `/outages` successfully creates a new report with `version: 1` and returns a `201 Created` status.
-   **Report Version Update**: Verifies that a `PATCH` request to `/outages/{ticket_id}` correctly adds a new version to an existing report.
-   **Report History Retrieval**: Verifies that a `GET` request to `/outages/{ticket_id}/history` returns the complete, correctly sorted list of all report versions.
-   **Error Handling**: Verifies that requesting the history for a non-existent ticket correctly returns a `404 Not Found` error.

---

## How to Test

1.  Install the required testing dependencies:
    ```bash
    pip install pytest httpx
    ```
2.  From the project's root directory, run the test suite:
    ```bash
    pytest
    ```
3.  **Observe**: All tests should pass, confirming that the API endpoints are functioning as expected.