### PR TITLE
feat: add bulk outage creation endpoint

### DIFF
--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -1,6 +1,8 @@
 from typing import List
 from fastapi import APIRouter, HTTPException
 from datetime import datetime
+from app.models.outage import BulkOutageCreate
+
 
 from app.models.outage import (
     ResolveOutageRequest,
@@ -109,3 +111,11 @@ def recompute_sla(outage_id: str):
 @router.get("/violations")
 def list_violations():
     return outage_store.list_violations()
+
+    @router.post("/bulk")
+def bulk_create_outages(payload: BulkOutageCreate):
+    created = outage_store.bulk_create(payload.outages)
+    return {
+        "count": len(created),
+        "items": created,
+    }

--- a/app/models/outage.py
+++ b/app/models/outage.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 from pydantic import BaseModel, Field
 
+
 class Location(BaseModel):
     latitude: float
     longitude: float
@@ -40,3 +41,6 @@ class PaginatedOutages(BaseModel):
 
 class ResolveOutageRequest(BaseModel):
     mttr_minutes: int
+
+class BulkOutageCreate(BaseModel):
+    outages: List[OutageCreate]

--- a/app/services/outage_store.py
+++ b/app/services/outage_store.py
@@ -84,6 +84,12 @@ class OutageStore:
 
         return violations
 
+        def bulk_create(self, outages: list[OutageCreate]):
+    created = []
+    for payload in outages:
+        created.append(self.create(payload))
+    return created
+
 
 # Singleton instance
 outage_store = OutageStore()


### PR DESCRIPTION
### PR Title

Add bulk outage creation endpoint

---

### PR Description

Adds a new endpoint to support creating multiple outages in a single request.

**Endpoint**

```
POST /api/v1/outages/bulk
```

**Acceptance**

* Supports creating many outages in one call

Closes #50 
