### PR TITLE
feat(backend): implement operational model migrations

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -9,6 +9,9 @@ from app.db.base import Base
 import app.models.orm.outage  # noqa: F401
 import app.models.orm.sla     # noqa: F401
 import app.models.orm.payment  # noqa: F401
+import app.models.job  # noqa: F401
+import app.models.webhook  # noqa: F401
+import app.models.sla_dispute  # noqa: F401
 
 from app.core.config import settings
 

--- a/alembic/versions/0003_operational_tables.py
+++ b/alembic/versions/0003_operational_tables.py
@@ -1,0 +1,151 @@
+"""add operational tables
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-03-25
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+job_status_enum = sa.Enum(
+    "pending",
+    "started",
+    "success",
+    "failure",
+    "revoked",
+    name="jobstatus",
+)
+job_type_enum = sa.Enum(
+    "sla_computation",
+    "webhook_dispatch",
+    "bulk_sla_computation",
+    name="jobtype",
+)
+webhook_event_enum = sa.Enum(
+    "sla.violation",
+    "sla.warning",
+    "sla.resolved",
+    name="webhookevent",
+)
+webhook_delivery_status_enum = sa.Enum(
+    "pending",
+    "success",
+    "failed",
+    "retrying",
+    name="webhookdeliverystatus",
+)
+dispute_status_enum = sa.Enum(
+    "pending",
+    "resolved",
+    "rejected",
+    name="disputestatus",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    job_status_enum.create(bind, checkfirst=True)
+    job_type_enum.create(bind, checkfirst=True)
+    webhook_event_enum.create(bind, checkfirst=True)
+    webhook_delivery_status_enum.create(bind, checkfirst=True)
+    dispute_status_enum.create(bind, checkfirst=True)
+
+    op.create_table(
+        "jobs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("celery_task_id", sa.String(length=255), nullable=False),
+        sa.Column("job_type", job_type_enum, nullable=False),
+        sa.Column("status", job_status_enum, nullable=False, server_default="pending"),
+        sa.Column("payload", sa.Text(), nullable=True),
+        sa.Column("result", sa.Text(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("progress", sa.Float(), nullable=True, server_default="0.0"),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_jobs_celery_task_id", "jobs", ["celery_task_id"], unique=True)
+
+    op.create_table(
+        "webhooks",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("url", sa.String(length=2048), nullable=False),
+        sa.Column("secret", sa.String(length=255), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("events", sa.Text(), nullable=False),
+        sa.Column("max_retries", sa.Integer(), nullable=False, server_default="3"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "webhook_deliveries",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("webhook_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("event", webhook_event_enum, nullable=False),
+        sa.Column("payload", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            webhook_delivery_status_enum,
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("next_retry_at", sa.DateTime(), nullable=True),
+        sa.Column("response_status_code", sa.Integer(), nullable=True),
+        sa.Column("response_body", sa.Text(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("delivered_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["webhook_id"], ["webhooks.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "sla_disputes",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("sla_result_id", sa.Integer(), nullable=False),
+        sa.Column("flagged_by", sa.String(length=255), nullable=False),
+        sa.Column("dispute_reason", sa.Text(), nullable=False),
+        sa.Column("flagged_at", sa.DateTime(), nullable=False),
+        sa.Column("status", dispute_status_enum, nullable=False, server_default="pending"),
+        sa.Column("resolved_by", sa.String(length=255), nullable=True),
+        sa.Column("resolution_notes", sa.Text(), nullable=True),
+        sa.Column("resolved_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["sla_result_id"], ["sla_results.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_sla_disputes_sla_result_id", "sla_disputes", ["sla_result_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    op.drop_index("ix_sla_disputes_sla_result_id", table_name="sla_disputes")
+    op.drop_table("sla_disputes")
+    op.drop_table("webhook_deliveries")
+    op.drop_table("webhooks")
+    op.drop_index("ix_jobs_celery_task_id", table_name="jobs")
+    op.drop_table("jobs")
+
+    dispute_status_enum.drop(bind, checkfirst=True)
+    webhook_delivery_status_enum.drop(bind, checkfirst=True)
+    webhook_event_enum.drop(bind, checkfirst=True)
+    job_type_enum.drop(bind, checkfirst=True)
+    job_status_enum.drop(bind, checkfirst=True)


### PR DESCRIPTION
This PR introduces Alembic migration coverage for operational models that remain in the repository, including jobs, webhooks, and SLA disputes. The goal is to ensure environments can be reliably bootstrapped with a consistent database schema.

By formalizing migrations for these models, this change eliminates ambiguity in setup, ensures reproducibility across environments, and maintains a coherent schema evolution history.

**Key Changes**

* Added Alembic migration scripts for retained models:

  * `job`
  * `webhook`
  * `sla_dispute`
* Ensured all required tables are created via `alembic upgrade head`
* Established a clean and consistent migration history for fresh database setup
* Aligned SQLAlchemy models with migration definitions

**Acceptance Criteria**

* Retained operational models have corresponding Alembic migrations
* Running `alembic upgrade head` creates all required tables
* Migration history supports a clean and coherent fresh setup

**Tech Stack / Files**

* Alembic
* SQLAlchemy
* `alembic/versions`
* `app/models/job.py`
* `app/models/webhook.py`
* `app/models/sla_dispute.py`

closes #84 