### PR TITLE
feat(backend): implement auth session endpoints

### DIFF
--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -1,6 +1,58 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Header, HTTPException, status
+
+from app.models.auth import (
+    AuthLogoutResponse,
+    AuthSessionResponse,
+    AuthUser,
+    LoginRequest,
+    RegisterRequest,
+)
+from app.services.auth_store import AuthStore
 
 router = APIRouter()
+
+
+def _extract_bearer_token(authorization: str | None) -> str:
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Missing Authorization header")
+
+    prefix = "Bearer "
+    if not authorization.startswith(prefix):
+        raise HTTPException(status_code=401, detail="Invalid Authorization header")
+    return authorization[len(prefix) :]
+
+
+@router.post("/register", response_model=AuthUser, status_code=status.HTTP_201_CREATED)
+def register(payload: RegisterRequest):
+    try:
+        return AuthStore.register(payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/login", response_model=AuthSessionResponse)
+def login(payload: LoginRequest):
+    try:
+        return AuthStore.login(payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+
+
+@router.get("/me", response_model=AuthUser)
+def me(authorization: str | None = Header(default=None)):
+    token = _extract_bearer_token(authorization)
+    user = AuthStore.get_user_for_token(token)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    return user
+
+
+@router.post("/logout", response_model=AuthLogoutResponse)
+def logout(authorization: str | None = Header(default=None)):
+    token = _extract_bearer_token(authorization)
+    AuthStore.logout(token)
+    return AuthLogoutResponse(message="Logged out successfully")
+
 
 @router.get("/ping")
 def auth_ping():

--- a/app/models/auth.py
+++ b/app/models/auth.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class AuthUser(BaseModel):
+    id: str
+    email: str
+    full_name: Optional[str] = None
+    role: str = "engineer"
+    stellar_wallet: Optional[str] = None
+    created_at: datetime
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str = Field(..., min_length=6)
+
+
+class RegisterRequest(LoginRequest):
+    full_name: str = Field(..., min_length=1)
+    role: str = "engineer"
+
+
+class AuthSessionResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+    expires_in: int = 3600
+    user: AuthUser
+
+
+class AuthLogoutResponse(BaseModel):
+    message: str

--- a/app/services/auth_store.py
+++ b/app/services/auth_store.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from app.models.auth import AuthSessionResponse, AuthUser, LoginRequest, RegisterRequest
+
+
+@dataclass
+class _StoredUser:
+    user: AuthUser
+    password: str
+
+
+class AuthStore:
+    _users_by_email: dict[str, _StoredUser] = {}
+    _sessions: dict[str, str] = {}
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(UTC)
+
+    @classmethod
+    def register(cls, payload: RegisterRequest) -> AuthUser:
+        if payload.email in cls._users_by_email:
+            raise ValueError("User already exists")
+
+        user = AuthUser(
+            id=f"user_{uuid4().hex[:8]}",
+            email=payload.email,
+            full_name=payload.full_name,
+            role=payload.role,
+            created_at=cls._now(),
+        )
+        cls._users_by_email[payload.email] = _StoredUser(user=user, password=payload.password)
+        return user
+
+    @classmethod
+    def login(cls, payload: LoginRequest) -> AuthSessionResponse:
+        stored = cls._users_by_email.get(payload.email)
+        if not stored or stored.password != payload.password:
+            raise ValueError("Invalid credentials")
+
+        access_token = f"atk_{uuid4().hex}"
+        refresh_token = f"rtk_{uuid4().hex}"
+        cls._sessions[access_token] = payload.email
+        return AuthSessionResponse(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            user=stored.user,
+        )
+
+    @classmethod
+    def get_user_for_token(cls, token: str) -> AuthUser | None:
+        email = cls._sessions.get(token)
+        if not email:
+            return None
+        stored = cls._users_by_email.get(email)
+        return stored.user if stored else None
+
+    @classmethod
+    def logout(cls, token: str) -> None:
+        cls._sessions.pop(token, None)


### PR DESCRIPTION
This PR replaces placeholder auth endpoints with a minimal but functional auth/session contract to support frontend integration. It enables the backend to expose usable authentication state, allowing the frontend to determine the current user or session status.

The auth surface is now properly defined and wired into the main API router, with updates reflected in the API docs for better visibility and usability.

**Key changes:**

* Replaced stub auth endpoints with functional implementations
* Added endpoint(s) to retrieve current user/session state
* Registered auth routes in the main API router
* Ensured auth surface is visible and documented in API docs

closes #83 