### PR TITLE
feat(backend): implement sla config endpoints

### DIFF
--- a/app/api/v1/endpoints/sla.py
+++ b/app/api/v1/endpoints/sla.py
@@ -4,9 +4,15 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
-from app.models.sla import SLAPerformanceAggregation, SLAPreviewRequest
+from app.models.sla import (
+    SLAConfigUpdateRequest,
+    SLAPerformanceAggregation,
+    SLAPreviewRequest,
+    SLASeverityConfig,
+)
 from app.repositories.sla_repository import SLARepository
 from app.services.sla import SLACalculator
+from app.services.sla.config import get_all_config, get_config_for_severity, update_config_for_severity
 from app.models import SLAResult
 
 router = APIRouter()
@@ -31,6 +37,27 @@ def preview_sla(payload: SLAPreviewRequest):
         mttr_minutes=payload.mttr_minutes,
     )
     return result
+
+
+@router.get("/config", response_model=dict[str, SLASeverityConfig])
+def get_sla_config():
+    return get_all_config()
+
+
+@router.get("/config/{severity}", response_model=SLASeverityConfig)
+def get_sla_config_by_severity(severity: str):
+    try:
+        return get_config_for_severity(severity)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+@router.put("/config/{severity}", response_model=SLASeverityConfig)
+def update_sla_config(severity: str, payload: SLAConfigUpdateRequest):
+    try:
+        return update_config_for_severity(severity, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get("/performance/aggregation", response_model=SLAPerformanceAggregation)

--- a/app/models/sla.py
+++ b/app/models/sla.py
@@ -8,6 +8,7 @@ class SLAPreviewRequest(BaseModel):
     severity: Severity
     mttr_minutes: int
 
+
 class SLAResult(BaseModel):
     outage_id: str
     status: Literal["met", "violated"]
@@ -16,6 +17,16 @@ class SLAResult(BaseModel):
     amount: int
     payment_type: Literal["reward", "penalty"]
     rating: Literal["exceptional", "excellent", "good", "poor"]
+
+
+class SLASeverityConfig(BaseModel):
+    threshold_minutes: int = Field(..., ge=0)
+    penalty_per_minute: int = Field(..., ge=0)
+    reward_base: int = Field(..., ge=0)
+
+
+class SLAConfigUpdateRequest(SLASeverityConfig):
+    pass
 
 
 class SLAPerformanceAggregation(BaseModel):

--- a/app/services/sla/config.py
+++ b/app/services/sla/config.py
@@ -1,3 +1,8 @@
+from copy import deepcopy
+
+from app.models.sla import SLAConfigUpdateRequest, SLASeverityConfig
+
+
 SLA_CONFIG = {
     "critical": {
         "threshold_minutes": 15,
@@ -20,3 +25,28 @@ SLA_CONFIG = {
         "reward_base": 600,
     },
 }
+
+
+def get_all_config() -> dict[str, SLASeverityConfig]:
+    return {
+        severity: SLASeverityConfig(**deepcopy(values))
+        for severity, values in SLA_CONFIG.items()
+    }
+
+
+def get_config_for_severity(severity: str) -> SLASeverityConfig:
+    normalized = severity.lower()
+    if normalized not in SLA_CONFIG:
+        raise ValueError(f"Unknown severity level: {severity}")
+    return SLASeverityConfig(**deepcopy(SLA_CONFIG[normalized]))
+
+
+def update_config_for_severity(
+    severity: str, payload: SLAConfigUpdateRequest
+) -> SLASeverityConfig:
+    normalized = severity.lower()
+    if normalized not in SLA_CONFIG:
+        raise ValueError(f"Unknown severity level: {severity}")
+
+    SLA_CONFIG[normalized] = payload.model_dump()
+    return SLASeverityConfig(**deepcopy(SLA_CONFIG[normalized]))


### PR DESCRIPTION
This PR introduces backend support for managing SLA configuration, enabling the frontend config screen to interact with real endpoints.

**Key Changes**

* Added SLA config read and update endpoints in `app/api/v1/endpoints/sla.py`
* Implemented config handling logic in `app/services/sla/config.py`
* Standardized config access by severity levels
* Defined and validated request/response models using Pydantic

**Acceptance Criteria Met**

* Backend exposes read SLA config endpoint
* Backend exposes update SLA config endpoint
* Config is addressed consistently by severity
* Request and response models are documented and validated

**Tech Stack**

* FastAPI
* Pydantic

closes #85