### PR TITLE
feat: typed outage PATCH, timeline persistence, payment reconciliatio…

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -7,6 +7,7 @@ from alembic import context
 # Import all ORM models so Alembic can detect them
 from app.db.base import Base
 import app.models.orm.outage  # noqa: F401
+import app.models.orm.outage_event  # noqa: F401
 import app.models.orm.sla     # noqa: F401
 import app.models.orm.payment  # noqa: F401
 import app.models.job  # noqa: F401

--- a/alembic/versions/0005_outage_events_payment_retry.py
+++ b/alembic/versions/0005_outage_events_payment_retry.py
@@ -1,0 +1,40 @@
+"""add outage_events and payment retry columns
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-03-30
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0005"
+down_revision: Union[str, None] = "0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "outage_events",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("outage_id", sa.String(), sa.ForeignKey("outages.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("event_type", sa.String(100), nullable=False),
+        sa.Column("detail", sa.Text(), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_outage_events_outage_id", "outage_events", ["outage_id"])
+
+    op.add_column("payment_transactions", sa.Column("retry_count", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column("payment_transactions", sa.Column("last_retried_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("payment_transactions", "last_retried_at")
+    op.drop_column("payment_transactions", "retry_count")
+    op.drop_index("ix_outage_events_outage_id", table_name="outage_events")
+    op.drop_table("outage_events")

--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -6,6 +6,7 @@ from app.models.enums import OutageStatus, Severity
 from app.models.outage import PaginatedOutages, ResolveOutageRequest
 from app.models import BulkOutageCreate, Outage, OutageCreate, OutageUpdate
 from app.repositories.outage_repository import OutageRepository
+from app.repositories.outage_event_repository import OutageEventRepository
 from app.repositories.payment_repository import PaymentRepository
 from app.repositories.sla_repository import SLARepository
 from app.services.audit_log import audit_log
@@ -67,6 +68,7 @@ def create_outage(payload: OutageCreate, db: Session = Depends(get_db)):
     repo = OutageRepository(db)
     outage = repo.create(payload)
     audit_log.log("outage_created", {"id": outage.id})
+    OutageEventRepository(db).record(outage.id, "created", {"site_name": outage.site_name})
     return outage
 
 
@@ -85,6 +87,19 @@ def update_outage(outage_id: str, payload: OutageUpdate, db: Session = Depends(g
         raise HTTPException(status_code=404, detail="Outage not found")
 
     updated = repo.update(outage_id, payload)
+    OutageEventRepository(db).record(outage_id, "updated", payload.model_dump(exclude_unset=True, exclude_none=True))
+    return updated
+
+
+@router.patch("/{outage_id}", response_model=Outage)
+def patch_outage(outage_id: str, payload: OutageUpdate, db: Session = Depends(get_db)):
+    repo = OutageRepository(db)
+    existing = repo.get(outage_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Outage not found")
+
+    updated = repo.update(outage_id, payload)
+    OutageEventRepository(db).record(outage_id, "patched", payload.model_dump(exclude_unset=True, exclude_none=True))
     return updated
 
 
@@ -107,6 +122,7 @@ def resolve_outage(outage_id: str, payload: ResolveOutageRequest, db: Session = 
         raise HTTPException(status_code=404, detail="Outage not found")
 
     audit_log.log("outage_resolved", {"id": outage.id, "mttr": payload.mttr_minutes})
+    OutageEventRepository(db).record(outage_id, "resolved", {"mttr_minutes": payload.mttr_minutes})
 
     raw_contract_result = SLAContractAdapter.calculate_sla(
         outage_id=outage.id,
@@ -117,6 +133,7 @@ def resolve_outage(outage_id: str, payload: ResolveOutageRequest, db: Session = 
 
     sla_repo = SLARepository(db)
     stored_sla = sla_repo.create_if_changed(sla)
+    OutageEventRepository(db).record(outage_id, "sla_computed", {"status": stored_sla.status})
     payment_repo = PaymentRepository(db)
     payment = payment_repo.create_for_sla_result(outage.id, stored_sla)
     webhook_event = (
@@ -163,4 +180,13 @@ def recompute_sla(outage_id: str, db: Session = Depends(get_db)):
     )
 
     audit_log.log("sla_recomputed", {"id": outage.id})
+    OutageEventRepository(db).record(outage_id, "sla_recomputed", {"status": stored_sla.status})
     return {"sla": stored_sla, "payment": payment}
+
+
+@router.get("/{outage_id}/timeline")
+def get_outage_timeline(outage_id: str, db: Session = Depends(get_db)):
+    repo = OutageRepository(db)
+    if not repo.get(outage_id):
+        raise HTTPException(status_code=404, detail="Outage not found")
+    return OutageEventRepository(db).list_for_outage(outage_id)

--- a/app/api/v1/endpoints/payments.py
+++ b/app/api/v1/endpoints/payments.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.models.payment import PaginatedPayments, PaymentTransaction
 from app.repositories.payment_repository import PaymentRepository
+from app.services.audit_log import audit_log
 
 router = APIRouter()
 
@@ -37,4 +39,31 @@ def get_payment(transaction_id: str, db: Session = Depends(get_db)):
     payment = repo.get(transaction_id)
     if not payment:
         raise HTTPException(status_code=404, detail="Payment not found")
+    return payment
+
+
+class ReconcileRequest(BaseModel):
+    status: str
+
+
+@router.post("/{transaction_id}/reconcile", response_model=PaymentTransaction)
+def reconcile_payment(transaction_id: str, payload: ReconcileRequest, db: Session = Depends(get_db)):
+    repo = PaymentRepository(db)
+    payment = repo.reconcile(transaction_id, payload.status)
+    if not payment:
+        raise HTTPException(status_code=404, detail="Payment not found")
+    audit_log.log("payment_reconciled", {"id": transaction_id, "status": payload.status})
+    return payment
+
+
+@router.post("/{transaction_id}/retry", response_model=PaymentTransaction)
+def retry_payment(transaction_id: str, db: Session = Depends(get_db)):
+    repo = PaymentRepository(db)
+    existing = repo.get(transaction_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Payment not found")
+    payment = repo.retry(transaction_id)
+    if not payment:
+        raise HTTPException(status_code=409, detail="Max retries reached")
+    audit_log.log("payment_retried", {"id": transaction_id, "retry_count": payment.retry_count})
     return payment

--- a/app/models/orm/outage_event.py
+++ b/app/models/orm/outage_event.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, ForeignKey, String, Text
+
+from app.db.base import Base
+
+
+class OutageEventORM(Base):
+    __tablename__ = "outage_events"
+
+    id = Column(String, primary_key=True, index=True)
+    outage_id = Column(String, ForeignKey("outages.id", ondelete="CASCADE"), nullable=False, index=True)
+    event_type = Column(String(100), nullable=False)  # e.g. "created", "resolved", "sla_computed", "recomputed"
+    detail = Column(Text, nullable=True)
+    occurred_at = Column(DateTime, nullable=False, default=datetime.utcnow)

--- a/app/models/orm/payment.py
+++ b/app/models/orm/payment.py
@@ -20,3 +20,5 @@ class PaymentTransactionORM(Base):
     sla_result_id = Column(Integer, ForeignKey("sla_results.id", ondelete="SET NULL"), nullable=True, index=True)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     confirmed_at = Column(DateTime, nullable=True)
+    retry_count = Column(Integer, nullable=False, default=0)
+    last_retried_at = Column(DateTime, nullable=True)

--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -17,6 +17,8 @@ class PaymentTransaction(BaseModel):
     sla_result_id: Optional[int] = None
     created_at: datetime
     confirmed_at: Optional[datetime] = None
+    retry_count: int = 0
+    last_retried_at: Optional[datetime] = None
 
 
 class PaginatedPayments(BaseModel):

--- a/app/repositories/outage_event_repository.py
+++ b/app/repositories/outage_event_repository.py
@@ -1,0 +1,44 @@
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from app.models.orm.outage_event import OutageEventORM
+
+
+class OutageEventRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def record(self, outage_id: str, event_type: str, detail: Optional[Dict[str, Any]] = None) -> OutageEventORM:
+        orm = OutageEventORM(
+            id=f"evt_{uuid4().hex[:12]}",
+            outage_id=outage_id,
+            event_type=event_type,
+            detail=json.dumps(detail) if detail else None,
+            occurred_at=datetime.utcnow(),
+        )
+        self.db.add(orm)
+        self.db.commit()
+        self.db.refresh(orm)
+        return orm
+
+    def list_for_outage(self, outage_id: str) -> List[Dict[str, Any]]:
+        rows = (
+            self.db.query(OutageEventORM)
+            .filter(OutageEventORM.outage_id == outage_id)
+            .order_by(OutageEventORM.occurred_at.asc())
+            .all()
+        )
+        return [
+            {
+                "id": r.id,
+                "outage_id": r.outage_id,
+                "event_type": r.event_type,
+                "detail": json.loads(r.detail) if r.detail else None,
+                "occurred_at": r.occurred_at.isoformat(),
+            }
+            for r in rows
+        ]

--- a/app/repositories/payment_repository.py
+++ b/app/repositories/payment_repository.py
@@ -23,6 +23,8 @@ def _orm_to_pydantic(orm: PaymentTransactionORM) -> PaymentTransaction:
         sla_result_id=orm.sla_result_id,
         created_at=orm.created_at,
         confirmed_at=orm.confirmed_at,
+        retry_count=orm.retry_count,
+        last_retried_at=orm.last_retried_at,
     )
 
 
@@ -138,3 +140,39 @@ class PaymentRepository:
             confirmed_at=None,
         )
         return self.create(transaction)
+
+    MAX_RETRIES = 3
+
+    def reconcile(self, transaction_id: str, new_status: str) -> Optional[PaymentTransaction]:
+        """Refresh payment status and mark as auditable reconciliation."""
+        orm = (
+            self.db.query(PaymentTransactionORM)
+            .filter(PaymentTransactionORM.id == transaction_id)
+            .first()
+        )
+        if not orm:
+            return None
+        orm.status = new_status
+        if new_status == "confirmed":
+            orm.confirmed_at = datetime.utcnow()
+        self.db.commit()
+        self.db.refresh(orm)
+        return _orm_to_pydantic(orm)
+
+    def retry(self, transaction_id: str) -> Optional[PaymentTransaction]:
+        """Increment retry counter (bounded by MAX_RETRIES) and reset to pending."""
+        orm = (
+            self.db.query(PaymentTransactionORM)
+            .filter(PaymentTransactionORM.id == transaction_id)
+            .first()
+        )
+        if not orm:
+            return None
+        if orm.retry_count >= self.MAX_RETRIES:
+            return None  # caller should raise 409
+        orm.retry_count += 1
+        orm.last_retried_at = datetime.utcnow()
+        orm.status = "pending"
+        self.db.commit()
+        self.db.refresh(orm)
+        return _orm_to_pydantic(orm)

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -20,10 +20,10 @@ def _sign_payload(secret: str, payload: str) -> str:
     return hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
 
 
-def _build_headers(webhook: Webhook, payload: str) -> Dict[str, str]:
+def _build_headers(webhook: Webhook, payload: str, event: WebhookEvent = WebhookEvent.SLA_VIOLATION) -> Dict[str, str]:
     headers = {
         "Content-Type": "application/json",
-        "X-Webhook-Event": WebhookEvent.SLA_VIOLATION,
+        "X-Webhook-Event": event.value,
         "X-Webhook-Timestamp": datetime.utcnow().isoformat(),
     }
     if webhook.secret:
@@ -64,7 +64,7 @@ def create_delivery(
 
 def _attempt_delivery(delivery: WebhookDelivery, webhook: Webhook) -> bool:
     payload_str = delivery.payload
-    headers = _build_headers(webhook, payload_str)
+    headers = _build_headers(webhook, payload_str, delivery.event)
 
     try:
         with httpx.Client(timeout=10.0) as client:


### PR DESCRIPTION
…n/retry, webhook signature fix

Closes #122  - Add typed outage PATCH endpoint
Closes #123  - Add outage timeline persistence and retrieval Closes #126 - Add payment reconciliation and retry hooks Closes #131  - Fix webhook signature generation and verification

- PATCH /api/v1/outages/{id} for partial typed updates (BE-022)
- OutageEventORM + OutageEventRepository to persist lifecycle events (BE-023)
- GET /api/v1/outages/{id}/timeline to retrieve ordered event history (BE-023)
- Timeline events emitted on create, update, patch, resolve, sla_computed, sla_recomputed (BE-023)
- POST /api/v1/payments/{id}/reconcile to refresh payment status with audit trail (BE-026)
- POST /api/v1/payments/{id}/retry bounded by MAX_RETRIES=3 with retry_count tracking (BE-026)
- Migration 0005: outage_events table + payment retry_count/last_retried_at columns (BE-023/BE-026)
- Fix _build_headers to use delivery.event instead of hardcoded SLA_VIOLATION (BE-031)
- Signature preserved consistently across initial delivery and retries (BE-031)