### PR TITLE
feat: bulk outage import, wallet trustline/funding-state endpoints, d…

### DIFF
--- a/alembic/versions/0005_dispute_audit_logs.py
+++ b/alembic/versions/0005_dispute_audit_logs.py
@@ -1,0 +1,34 @@
+"""add dispute audit logs table
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-03-30
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+from alembic import op
+
+revision: str = "0005"
+down_revision: Union[str, None] = "0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dispute_audit_logs",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("dispute_id", UUID(as_uuid=True), sa.ForeignKey("sla_disputes.id"), nullable=False, index=True),
+        sa.Column("action", sa.String(50), nullable=False),
+        sa.Column("actor", sa.String(255), nullable=False),
+        sa.Column("notes", sa.Text, nullable=True),
+        sa.Column("recorded_at", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("dispute_audit_logs")

--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -1,4 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException, Response
+import csv
+import io
+import json
+
+from fastapi import APIRouter, Depends, File, HTTPException, Response, UploadFile
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
@@ -75,6 +79,42 @@ def bulk_create_outages(payload: BulkOutageCreate, db: Session = Depends(get_db)
     repo = OutageRepository(db)
     created = repo.bulk_create(payload.outages)
     return {"count": len(created), "items": created}
+
+
+@router.post("/import", response_model=dict, summary="Bulk import outages from CSV or JSON file")
+async def import_outages(file: UploadFile = File(...), db: Session = Depends(get_db)):
+    content = await file.read()
+    filename = file.filename or ""
+
+    imported, skipped, errors = [], [], []
+
+    if filename.endswith(".json"):
+        try:
+            rows = json.loads(content)
+            if not isinstance(rows, list):
+                raise HTTPException(status_code=400, detail="JSON file must contain a list of outage objects")
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=400, detail=f"Invalid JSON: {exc}") from exc
+    elif filename.endswith(".csv"):
+        try:
+            reader = csv.DictReader(io.StringIO(content.decode("utf-8")))
+            rows = list(reader)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"Invalid CSV: {exc}") from exc
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported file format. Use .json or .csv")
+
+    repo = OutageRepository(db)
+    for i, row in enumerate(rows):
+        try:
+            payload = OutageCreate(**row)
+            repo.create(payload)
+            imported.append(payload.id)
+        except Exception as exc:
+            skipped.append(i)
+            errors.append({"row": i, "error": str(exc)})
+
+    return {"imported": len(imported), "skipped": len(skipped), "errors": errors}
 
 
 @router.put("/{outage_id}", response_model=Outage)

--- a/app/api/v1/endpoints/sla_dispute.py
+++ b/app/api/v1/endpoints/sla_dispute.py
@@ -4,8 +4,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
-from app.models.sla_dispute import SLADispute, DisputeStatus
-from app.schemas.sla_dispute import DisputeFlagRequest, DisputeResolveRequest, DisputeResponse
+from app.models.sla_dispute import DisputeAuditLog, SLADispute, DisputeStatus
+from app.schemas.sla_dispute import DisputeAuditLogResponse, DisputeFlagRequest, DisputeResolveRequest, DisputeResponse
 
 router = APIRouter()
 
@@ -56,6 +56,14 @@ def flag_dispute(
         dispute_reason=payload.dispute_reason,
     )
     db.add(dispute)
+    db.flush()
+
+    db.add(DisputeAuditLog(
+        dispute_id=dispute.id,
+        action="flagged",
+        actor=payload.flagged_by,
+        notes=payload.dispute_reason,
+    ))
     db.commit()
     db.refresh(dispute)
     return dispute
@@ -96,6 +104,12 @@ def resolve_dispute(
     dispute.resolution_notes = payload.resolution_notes
     dispute.resolved_at = datetime.utcnow()
 
+    db.add(DisputeAuditLog(
+        dispute_id=dispute.id,
+        action=payload.status.value,
+        actor=payload.resolved_by,
+        notes=payload.resolution_notes,
+    ))
     db.commit()
     db.refresh(dispute)
     return dispute
@@ -122,3 +136,26 @@ def get_dispute(
             detail="No dispute found for this SLA result.",
         )
     return dispute
+
+
+@router.get(
+    "/{sla_result_id}/dispute/history",
+    response_model=list[DisputeAuditLogResponse],
+    summary="Get audit trail for a dispute",
+)
+def get_dispute_history(
+    sla_result_id: int,
+    db: Session = Depends(get_db),
+):
+    dispute = (
+        db.query(SLADispute)
+        .filter(SLADispute.sla_result_id == sla_result_id)
+        .order_by(SLADispute.flagged_at.desc())
+        .first()
+    )
+    if not dispute:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No dispute found for this SLA result.",
+        )
+    return dispute.audit_logs

--- a/app/api/v1/endpoints/wallets.py
+++ b/app/api/v1/endpoints/wallets.py
@@ -5,8 +5,10 @@ from app.models.wallet import (
     WalletBalanceResponse,
     WalletCreateRequest,
     WalletCreateResponse,
+    WalletFundingStateResponse,
     WalletLinkRequest,
     WalletStatusResponse,
+    WalletTrustlineResponse,
 )
 from app.services.wallet_registry import WalletRegistry
 
@@ -42,6 +44,22 @@ def get_wallet_status(user_id: str):
     if not wallet_status:
         raise HTTPException(status_code=404, detail="Wallet not found")
     return wallet_status
+
+
+@router.get("/{user_id}/trustline", response_model=WalletTrustlineResponse, summary="Check trustline readiness for a wallet")
+def get_wallet_trustline(user_id: str):
+    result = WalletRegistry.get_trustline(user_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Wallet not found")
+    return result
+
+
+@router.get("/{user_id}/funding-state", response_model=WalletFundingStateResponse, summary="Get current funding state of a wallet")
+def get_wallet_funding_state(user_id: str):
+    result = WalletRegistry.get_funding_state(user_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Wallet not found")
+    return result
 
 
 @router.get("/{address}/balance", response_model=WalletBalanceResponse)

--- a/app/models/sla_dispute.py
+++ b/app/models/sla_dispute.py
@@ -33,3 +33,17 @@ class SLADispute(Base):
     resolved_at = Column(DateTime, nullable=True)
 
     sla_result = relationship("SLAResultORM", back_populates="disputes")
+    audit_logs = relationship("DisputeAuditLog", back_populates="dispute", order_by="DisputeAuditLog.recorded_at")
+
+
+class DisputeAuditLog(Base):
+    __tablename__ = "dispute_audit_logs"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    dispute_id = Column(UUID(as_uuid=True), ForeignKey("sla_disputes.id"), nullable=False, index=True)
+    action = Column(String(50), nullable=False)  # e.g. "flagged", "resolved", "rejected"
+    actor = Column(String(255), nullable=False)
+    notes = Column(Text, nullable=True)
+    recorded_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    dispute = relationship("SLADispute", back_populates="audit_logs")

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -50,3 +50,17 @@ class WalletStatusResponse(BaseModel):
     usable: bool
     active: bool
     last_updated: datetime
+
+
+class WalletTrustlineResponse(BaseModel):
+    user_id: str
+    public_key: str
+    trustline_ready: bool
+    trustline_error: Optional[str] = None
+
+
+class WalletFundingStateResponse(BaseModel):
+    user_id: str
+    public_key: str
+    funded: bool
+    funding_error: Optional[str] = None

--- a/app/schemas/sla_dispute.py
+++ b/app/schemas/sla_dispute.py
@@ -29,3 +29,15 @@ class DisputeResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class DisputeAuditLogResponse(BaseModel):
+    id: str
+    dispute_id: str
+    action: str
+    actor: str
+    notes: Optional[str] = None
+    recorded_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/app/services/wallet_registry.py
+++ b/app/services/wallet_registry.py
@@ -9,8 +9,10 @@ from app.models.wallet import (
     WalletBalanceResponse,
     WalletCreateRequest,
     WalletCreateResponse,
+    WalletFundingStateResponse,
     WalletLinkRequest,
     WalletStatusResponse,
+    WalletTrustlineResponse,
 )
 
 
@@ -111,4 +113,32 @@ class WalletRegistry:
             usable=wallet.funded and wallet.trustline_ready and wallet.active,
             active=wallet.active,
             last_updated=wallet.last_updated,
+        )
+
+    @classmethod
+    def get_trustline(cls, user_id: str) -> WalletTrustlineResponse | None:
+        wallet = cls.get_wallet(user_id)
+        if not wallet:
+            return None
+
+        error = None if wallet.trustline_ready else "Trustline not established. Fund wallet and set up USDC trustline."
+        return WalletTrustlineResponse(
+            user_id=wallet.user_id,
+            public_key=wallet.public_key,
+            trustline_ready=wallet.trustline_ready,
+            trustline_error=error,
+        )
+
+    @classmethod
+    def get_funding_state(cls, user_id: str) -> WalletFundingStateResponse | None:
+        wallet = cls.get_wallet(user_id)
+        if not wallet:
+            return None
+
+        error = None if wallet.funded else "Wallet is not funded. Send at least 1 XLM to activate."
+        return WalletFundingStateResponse(
+            user_id=wallet.user_id,
+            public_key=wallet.public_key,
+            funded=wallet.funded,
+            funding_error=error,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ alembic
 pydantic-settings
 celery
 httpx
+python-multipart


### PR DESCRIPTION
…ispute audit trail

- [BE-024] POST /outages/import accepts .csv or .json file upload, returns imported/skipped/errors summary
- [BE-027] GET /wallets/{user_id}/funding-state returns funded state with clear error messaging
- [BE-028] GET /wallets/{user_id}/trustline returns trustline readiness with failure state for FE
- [BE-030] dispute audit log model + migration; flag/resolve writes audit entries; GET /{id}/dispute/history returns full trail
- Add WalletTrustlineResponse and WalletFundingStateResponse models
- Add DisputeAuditLog ORM model and DisputeAuditLogResponse schema
- Add alembic migration 0005 for dispute_audit_logs table
- Add python-multipart to requirements.txt

closes #130 
closes #128 
closes #124 
closes #127 