### PR TITLE
Implement audit for auth session life cycle

### DIFF
--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Header, HTTPException, status
+from fastapi import APIRouter, Header, HTTPException, status, Depends
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
 
 from app.models.auth import (
     AuthLogoutResponse,
@@ -9,6 +10,7 @@ from app.models.auth import (
     RegisterRequest,
 )
 from app.services.auth_store import AuthStore
+from app.db.session import get_db
 
 router = APIRouter()
 
@@ -28,42 +30,46 @@ class RefreshRequest(BaseModel):
 
 
 @router.post("/register", response_model=AuthUser, status_code=status.HTTP_201_CREATED)
-def register(payload: RegisterRequest):
+def register(payload: RegisterRequest, db: Session = Depends(get_db)):
     try:
-        return AuthStore.register(payload)
+        return AuthStore.register(payload, db=db)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post("/login", response_model=AuthSessionResponse)
-def login(payload: LoginRequest):
+def login(payload: LoginRequest, db: Session = Depends(get_db)):
     try:
-        return AuthStore.login(payload)
+        return AuthStore.login(payload, db=db)
     except ValueError as exc:
         raise HTTPException(status_code=401, detail=str(exc)) from exc
 
 
 @router.post("/refresh", response_model=AuthSessionResponse)
-def refresh(payload: RefreshRequest):
+def refresh(payload: RefreshRequest, db: Session = Depends(get_db)):
     try:
-        return AuthStore.refresh(payload.refresh_token)
+        return AuthStore.refresh(payload.refresh_token, db=db)
     except ValueError as exc:
         raise HTTPException(status_code=401, detail=str(exc)) from exc
 
 
 @router.get("/me", response_model=AuthUser)
-def me(authorization: str | None = Header(default=None)):
+def me(
+    authorization: str | None = Header(default=None), db: Session = Depends(get_db)
+):
     token = _extract_bearer_token(authorization)
-    user = AuthStore.get_user_for_token(token)
+    user = AuthStore.get_user_for_token(token, db=db)
     if not user:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
     return user
 
 
 @router.post("/logout", response_model=AuthLogoutResponse)
-def logout(authorization: str | None = Header(default=None)):
+def logout(
+    authorization: str | None = Header(default=None), db: Session = Depends(get_db)
+):
     token = _extract_bearer_token(authorization)
-    AuthStore.logout(token)
+    AuthStore.logout(token, db=db)
     return AuthLogoutResponse(message="Logged out successfully")
 
 

--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -51,12 +51,23 @@ def list_violations(db: Session = Depends(get_db)):
 def list_outages(
     severity: Severity | None = None,
     status: OutageStatus | None = None,
+    search: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
     page: int = 1,
     page_size: int = 20,
     db: Session = Depends(get_db),
 ):
     repo = OutageRepository(db)
-    return repo.list(severity, status, page, page_size)
+    return repo.list(
+        severity=severity,
+        status=status,
+        search=search,
+        start_date=start_date,
+        end_date=end_date,
+        page=page,
+        page_size=page_size,
+    )
 
 
 @router.get("/{outage_id}", response_model=Outage)

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,0 +1,31 @@
+import re
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+def validate_password_policy(password: str) -> bool:
+    """
+    Enforce a password policy:
+    - At least 8 characters long
+    - At least one uppercase letter
+    - At least one lowercase letter
+    - At least one digit
+    - At least one special character
+    """
+    if len(password) < 8:
+        return False
+    if not re.search(r"[a-z]", password):
+        return False
+    if not re.search(r"[A-Z]", password):
+        return False
+    if not re.search(r"\d", password):
+        return False
+    if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", password):
+        return False
+    return True

--- a/app/models/orm/__init__.py
+++ b/app/models/orm/__init__.py
@@ -1,6 +1,17 @@
 from app.models.orm.outage import OutageORM
 from app.models.orm.sla import SLAResultORM
 from app.models.orm.payment import PaymentTransactionORM
+from app.models.orm.user import UserORM
+from app.models.orm.session import SessionORM
+from app.models.orm.audit_log import AuditLogORM
 from app.models.sla_dispute import SLADispute
 
-__all__ = ["OutageORM", "SLAResultORM", "PaymentTransactionORM", "SLADispute"]
+__all__ = [
+    "OutageORM",
+    "SLAResultORM",
+    "PaymentTransactionORM",
+    "UserORM",
+    "SessionORM",
+    "AuditLogORM",
+    "SLADispute",
+]

--- a/app/models/orm/audit_log.py
+++ b/app/models/orm/audit_log.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from sqlalchemy import Column, DateTime, String, Integer, JSON
+from app.db.base import Base
+
+class AuditLogORM(Base):
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+    event_type = Column(String(100), index=True, nullable=False)
+    email = Column(String(255), index=True, nullable=True)
+    details = Column(JSON, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)

--- a/app/models/orm/session.py
+++ b/app/models/orm/session.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from sqlalchemy import Column, DateTime, String, ForeignKey
+from app.db.base import Base
+
+class SessionORM(Base):
+    __tablename__ = "sessions"
+
+    access_token = Column(String(255), primary_key=True, index=True)
+    refresh_token = Column(String(255), unique=True, index=True, nullable=False)
+    email = Column(String(255), ForeignKey("users.email"), nullable=False)
+    expires_at = Column(DateTime, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)

--- a/app/models/orm/user.py
+++ b/app/models/orm/user.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from sqlalchemy import Column, DateTime, String
+from app.db.base import Base
+
+class UserORM(Base):
+    __tablename__ = "users"
+
+    id = Column(String, primary_key=True, index=True)
+    email = Column(String(255), unique=True, index=True, nullable=False)
+    hashed_password = Column(String(255), nullable=False)
+    full_name = Column(String(255), nullable=True)
+    role = Column(String(50), default="engineer")
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -1,5 +1,15 @@
+from app.repositories.outage_event_repository import OutageEventRepository
 from app.repositories.outage_repository import OutageRepository
-from app.repositories.sla_repository import SLARepository
 from app.repositories.payment_repository import PaymentRepository
+from app.repositories.sla_repository import SLARepository
+from app.repositories.user_repository import UserRepository
+from app.repositories.session_repository import SessionRepository
 
-__all__ = ["OutageRepository", "SLARepository", "PaymentRepository"]
+__all__ = [
+    "OutageRepository",
+    "OutageEventRepository",
+    "PaymentRepository",
+    "SLARepository",
+    "UserRepository",
+    "SessionRepository",
+]

--- a/app/repositories/outage_repository.py
+++ b/app/repositories/outage_repository.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import List, Optional
 
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from app.models.enums import OutageStatus, Severity
@@ -44,6 +45,9 @@ class OutageRepository:
         self,
         severity: Optional[Severity] = None,
         status: Optional[OutageStatus] = None,
+        search: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
         page: int = 1,
         page_size: int = 20,
     ) -> dict:
@@ -53,6 +57,22 @@ class OutageRepository:
             query = query.filter(OutageORM.severity == severity.value)
         if status:
             query = query.filter(OutageORM.status == status.value)
+
+        if search:
+            search_filter = or_(
+                OutageORM.id.ilike(f"%{search}%"),
+                OutageORM.site_id.ilike(f"%{search}%"),
+                OutageORM.site_name.ilike(f"%{search}%"),
+            )
+            query = query.filter(search_filter)
+
+        if start_date:
+            query = query.filter(OutageORM.detected_at >= start_date)
+        if end_date:
+            query = query.filter(OutageORM.detected_at <= end_date)
+
+        # Ensure stable pagination
+        query = query.order_by(OutageORM.detected_at.desc(), OutageORM.id.asc())
 
         total = query.count()
         items = query.offset((page - 1) * page_size).limit(page_size).all()

--- a/app/repositories/session_repository.py
+++ b/app/repositories/session_repository.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from typing import Optional
+from sqlalchemy.orm import Session
+from app.models.orm.session import SessionORM
+
+class SessionRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_session(self, access_token: str, refresh_token: str, email: str, expires_at: datetime) -> SessionORM:
+        session = SessionORM(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            email=email,
+            expires_at=expires_at
+        )
+        self.db.add(session)
+        self.db.commit()
+        self.db.refresh(session)
+        return session
+
+    def get_session(self, access_token: str) -> Optional[SessionORM]:
+        return self.db.query(SessionORM).filter(SessionORM.access_token == access_token).first()
+
+    def get_session_by_refresh_token(self, refresh_token: str) -> Optional[SessionORM]:
+        return self.db.query(SessionORM).filter(SessionORM.refresh_token == refresh_token).first()
+
+    def delete_session(self, access_token: str) -> None:
+        session = self.get_session(access_token)
+        if session:
+            self.db.delete(session)
+            self.db.commit()

--- a/app/repositories/user_repository.py
+++ b/app/repositories/user_repository.py
@@ -1,0 +1,36 @@
+from typing import Optional
+from sqlalchemy.orm import Session
+from app.models.orm.user import UserORM
+from app.models.auth import AuthUser
+
+def user_orm_to_pydantic(orm: UserORM) -> AuthUser:
+    return AuthUser(
+        id=orm.id,
+        email=orm.email,
+        full_name=orm.full_name,
+        role=orm.role,
+        created_at=orm.created_at,
+    )
+
+class UserRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_by_email(self, email: str) -> Optional[UserORM]:
+        return self.db.query(UserORM).filter(UserORM.email == email).first()
+
+    def get_by_id(self, user_id: str) -> Optional[UserORM]:
+        return self.db.query(UserORM).filter(UserORM.id == user_id).first()
+
+    def create(self, user_id: str, email: str, hashed_password: str, full_name: str, role: str) -> UserORM:
+        user = UserORM(
+            id=user_id,
+            email=email,
+            hashed_password=hashed_password,
+            full_name=full_name,
+            role=role
+        )
+        self.db.add(user)
+        self.db.commit()
+        self.db.refresh(user)
+        return user

--- a/app/services/audit_log.py
+++ b/app/services/audit_log.py
@@ -1,41 +1,47 @@
-import json
-import os
-from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any
+from datetime import datetime
+from typing import Any, Optional
+from sqlalchemy.orm import Session
+from app.models.orm.audit_log import AuditLogORM
+from app.db.session import SessionLocal
 
+class AuditLogService:
+    def __init__(self, db_session_factory=None):
+        self.db_session_factory = db_session_factory or SessionLocal
 
-class AuditLogStore:
-    def __init__(self, file_path: str | None = None):
-        default_path = Path(__file__).resolve().parents[2] / ".runtime" / "audit-log.jsonl"
-        configured_path = Path(file_path) if file_path else Path(
-            os.getenv("NOCIQ_AUDIT_LOG_PATH", default_path)
+    def log_event(
+        self,
+        db: Session,
+        event_type: str,
+        email: Optional[str] = None,
+        details: Optional[dict[str, Any]] = None
+    ) -> None:
+        """
+        Records a structured audit event.
+        Ensures sensitive data like passwords or tokens are NOT leaked into details.
+        """
+        # Sanitization: prevent leaking common sensitive keys
+        safe_details = details.copy() if details else {}
+        sensitive_keys = {"password", "token", "access_token", "refresh_token", "secret"}
+        for key in sensitive_keys:
+            if key in safe_details:
+                safe_details[key] = "[REDACTED]"
+
+        audit_entry = AuditLogORM(
+            event_type=event_type,
+            email=email,
+            details=safe_details,
+            created_at=datetime.utcnow()
         )
-        self._file_path = configured_path
-        self._file_path.parent.mkdir(parents=True, exist_ok=True)
-        self._file_path.touch(exist_ok=True)
+        db.add(audit_entry)
+        db.commit()
 
-    def log(self, action: str, payload: dict[str, Any]):
-        entry = {
-            "timestamp": datetime.now(UTC).isoformat(),
-            "action": action,
-            "payload": payload,
-        }
-        with self._file_path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(entry) + "\n")
+    def log(self, event_type: str, details: Optional[dict[str, Any]] = None) -> None:
+        """
+        Simplified log method for compatibility with existing code.
+        Uses its own session if not provided.
+        """
+        with self.db_session_factory() as db:
+            self.log_event(db, event_type, details=details)
 
-    def list(self):
-        entries = []
-        with self._file_path.open("r", encoding="utf-8") as handle:
-            for line in handle:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entries.append(json.loads(line))
-                except json.JSONDecodeError:
-                    continue
-        return list(reversed(entries))
-
-
-audit_log = AuditLogStore()
+# Create a singleton instance for common use
+audit_log = AuditLogService()

--- a/app/services/auth_store.py
+++ b/app/services/auth_store.py
@@ -1,123 +1,187 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from uuid import uuid4
+from sqlalchemy.orm import Session
 
 from app.models.auth import AuthSessionResponse, AuthUser, LoginRequest, RegisterRequest
+from app.models.orm.user import UserORM
+from app.repositories.user_repository import UserRepository, user_orm_to_pydantic
+from app.repositories.session_repository import SessionRepository
+from app.core.security import get_password_hash, verify_password, validate_password_policy
+from app.services.audit_log import audit_log
+from app.db.session import SessionLocal
 
 TOKEN_TTL_SECONDS = 3600
 
-
-@dataclass
-class _StoredUser:
-    user: AuthUser
-    password: str
-
-
-@dataclass
-class _Session:
-    email: str
-    expires_at: datetime
-    refresh_token: str
-
-
 class AuthStore:
-    _users_by_email: dict[str, _StoredUser] = {}
-    _sessions: dict[str, _Session] = {}          # access_token -> _Session
-    _refresh_tokens: dict[str, str] = {}          # refresh_token -> access_token
-
     @staticmethod
     def _now() -> datetime:
         return datetime.now(UTC)
 
     @classmethod
-    def register(cls, payload: RegisterRequest) -> AuthUser:
-        if payload.email in cls._users_by_email:
-            raise ValueError("User already exists")
-
-        user = AuthUser(
-            id=f"user_{uuid4().hex[:8]}",
-            email=payload.email,
-            full_name=payload.full_name,
-            role=payload.role,
-            created_at=cls._now(),
-        )
-        cls._users_by_email[payload.email] = _StoredUser(user=user, password=payload.password)
-        return user
+    def register(cls, payload: RegisterRequest, db: Session = None) -> AuthUser:
+        if db is None:
+            with SessionLocal() as db:
+                return cls._register_with_db(payload, db)
+        return cls._register_with_db(payload, db)
 
     @classmethod
-    def login(cls, payload: LoginRequest) -> AuthSessionResponse:
-        stored = cls._users_by_email.get(payload.email)
-        if not stored or stored.password != payload.password:
+    def _register_with_db(cls, payload: RegisterRequest, db: Session) -> AuthUser:
+        user_repo = UserRepository(db)
+        if user_repo.get_by_email(payload.email):
+            raise ValueError("User already exists")
+
+        if not validate_password_policy(payload.password):
+            raise ValueError(
+                "Password does not meet policy requirements (min 8 chars, "
+                "uppercase, lowercase, digit, special char)"
+            )
+
+        hashed_password = get_password_hash(payload.password)
+        user_id = f"user_{uuid4().hex[:8]}"
+        
+        orm_user = user_repo.create(
+            user_id=user_id,
+            email=payload.email,
+            hashed_password=hashed_password,
+            full_name=payload.full_name,
+            role=payload.role
+        )
+
+        audit_log.log_event(
+            db, 
+            "registration", 
+            email=payload.email, 
+            details={"user_id": user_id, "role": payload.role}
+        )
+        
+        return user_orm_to_pydantic(orm_user)
+
+    @classmethod
+    def login(cls, payload: LoginRequest, db: Session = None) -> AuthSessionResponse:
+        if db is None:
+            with SessionLocal() as db:
+                return cls._login_with_db(payload, db)
+        return cls._login_with_db(payload, db)
+
+    @classmethod
+    def _login_with_db(cls, payload: LoginRequest, db: Session) -> AuthSessionResponse:
+        user_repo = UserRepository(db)
+        session_repo = SessionRepository(db)
+        
+        stored_user = user_repo.get_by_email(payload.email)
+        if not stored_user or not verify_password(payload.password, stored_user.hashed_password):
+            audit_log.log_event(db, "login_failed", email=payload.email)
             raise ValueError("Invalid credentials")
 
         access_token = f"atk_{uuid4().hex}"
         refresh_token = f"rtk_{uuid4().hex}"
         expires_at = cls._now() + timedelta(seconds=TOKEN_TTL_SECONDS)
-        cls._sessions[access_token] = _Session(
-            email=payload.email,
-            expires_at=expires_at,
+        
+        session_repo.create_session(
+            access_token=access_token,
             refresh_token=refresh_token,
+            email=payload.email,
+            expires_at=expires_at
         )
-        cls._refresh_tokens[refresh_token] = access_token
+
+        audit_log.log_event(db, "login_success", email=payload.email)
+        
         return AuthSessionResponse(
             access_token=access_token,
             refresh_token=refresh_token,
             expires_in=TOKEN_TTL_SECONDS,
-            user=stored.user,
+            user=user_orm_to_pydantic(stored_user),
         )
 
     @classmethod
-    def get_user_for_token(cls, token: str) -> AuthUser | None:
-        session = cls._sessions.get(token)
-        if not session:
-            return None
-        if cls._now() > session.expires_at:
-            cls._invalidate_session(token)
-            return None
-        stored = cls._users_by_email.get(session.email)
-        return stored.user if stored else None
+    def get_user_for_token(cls, token: str, db: Session = None) -> AuthUser | None:
+        if db is None:
+            with SessionLocal() as db:
+                return cls._get_user_for_token_with_db(token, db)
+        return cls._get_user_for_token_with_db(token, db)
 
     @classmethod
-    def refresh(cls, refresh_token: str) -> AuthSessionResponse:
-        old_access = cls._refresh_tokens.get(refresh_token)
-        if not old_access:
-            raise ValueError("Invalid or expired refresh token")
-
-        session = cls._sessions.get(old_access)
+    def _get_user_for_token_with_db(cls, token: str, db: Session) -> AuthUser | None:
+        session_repo = SessionRepository(db)
+        user_repo = UserRepository(db)
+        
+        session = session_repo.get_session(token)
         if not session:
+            return None
+        
+        # Check if expired
+        # session.expires_at might be offset-naive or aware depending on how it was stored.
+        # SQLAlchemy DateTime usually returns naive. We need to compare carefully.
+        now = datetime.utcnow()
+        expires_at = session.expires_at
+        if expires_at.tzinfo is not None:
+             now = datetime.now(UTC).replace(tzinfo=None) # Keep it naive for comparison if needed
+             expires_at = expires_at.replace(tzinfo=None)
+
+        if now > expires_at:
+            session_repo.delete_session(token)
+            return None
+            
+        stored_user = user_repo.get_by_email(session.email)
+        return user_orm_to_pydantic(stored_user) if stored_user else None
+
+    @classmethod
+    def refresh(cls, refresh_token: str, db: Session = None) -> AuthSessionResponse:
+        if db is None:
+            with SessionLocal() as db:
+                return cls._refresh_with_db(refresh_token, db)
+        return cls._refresh_with_db(refresh_token, db)
+
+    @classmethod
+    def _refresh_with_db(cls, refresh_token: str, db: Session) -> AuthSessionResponse:
+        session_repo = SessionRepository(db)
+        user_repo = UserRepository(db)
+        
+        old_session = session_repo.get_session_by_refresh_token(refresh_token)
+        if not old_session:
             raise ValueError("Invalid or expired refresh token")
 
-        email = session.email
-        cls._invalidate_session(old_access)
+        email = old_session.email
+        session_repo.delete_session(old_session.access_token)
 
-        stored = cls._users_by_email.get(email)
-        if not stored:
+        stored_user = user_repo.get_by_email(email)
+        if not stored_user:
             raise ValueError("User not found")
 
         new_access = f"atk_{uuid4().hex}"
         new_refresh = f"rtk_{uuid4().hex}"
         expires_at = cls._now() + timedelta(seconds=TOKEN_TTL_SECONDS)
-        cls._sessions[new_access] = _Session(
-            email=email,
-            expires_at=expires_at,
+        
+        session_repo.create_session(
+            access_token=new_access,
             refresh_token=new_refresh,
+            email=email,
+            expires_at=expires_at
         )
-        cls._refresh_tokens[new_refresh] = new_access
+
+        audit_log.log_event(db, "refresh", email=email)
+        
         return AuthSessionResponse(
             access_token=new_access,
             refresh_token=new_refresh,
             expires_in=TOKEN_TTL_SECONDS,
-            user=stored.user,
+            user=user_orm_to_pydantic(stored_user),
         )
 
     @classmethod
-    def logout(cls, token: str) -> None:
-        cls._invalidate_session(token)
+    def logout(cls, token: str, db: Session = None) -> None:
+        if db is None:
+            with SessionLocal() as db:
+                return cls._logout_with_db(token, db)
+        return cls._logout_with_db(token, db)
 
     @classmethod
-    def _invalidate_session(cls, access_token: str) -> None:
-        session = cls._sessions.pop(access_token, None)
+    def _logout_with_db(cls, token: str, db: Session) -> None:
+        session_repo = SessionRepository(db)
+        session = session_repo.get_session(token)
         if session:
-            cls._refresh_tokens.pop(session.refresh_token, None)
+            email = session.email
+            session_repo.delete_session(token)
+            audit_log.log_event(db, "logout", email=email)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pydantic-settings
 celery
 httpx
 python-multipart
+passlib[bcrypt]

--- a/tests/test_auth_audit.py
+++ b/tests/test_auth_audit.py
@@ -1,0 +1,87 @@
+import pytest
+from sqlalchemy.orm import Session
+from app.services.auth_store import AuthStore
+from app.models.auth import RegisterRequest, LoginRequest
+from app.models.orm.audit_log import AuditLogORM
+from app.db.session import SessionLocal
+
+@pytest.fixture
+def db():
+    # Use a real session but clean up or use a test DB if configured
+    # For now, we'll assume the environment handles test DB or we use the default
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+def test_registration_audit(db: Session):
+    email = "audit_test@example.com"
+    payload = RegisterRequest(
+        email=email,
+        password="Password123!",
+        full_name="Audit Test",
+        role="engineer"
+    )
+    
+    AuthStore.register(payload, db=db)
+    
+    # Check audit log
+    log = db.query(AuditLogORM).filter(AuditLogORM.email == email, AuditLogORM.event_type == "registration").first()
+    assert log is not None
+    assert log.details["role"] == "engineer"
+    assert "password" not in log.details or log.details["password"] == "[REDACTED]"
+
+def test_login_audit(db: Session):
+    email = "login_audit@example.com"
+    password = "Password123!"
+    # Register first
+    AuthStore.register(RegisterRequest(
+        email=email,
+        password=password,
+        full_name="Login Audit",
+        role="engineer"
+    ), db=db)
+    
+    # Login
+    AuthStore.login(LoginRequest(email=email, password=password), db=db)
+    
+    # Check audit log
+    log = db.query(AuditLogORM).filter(AuditLogORM.email == email, AuditLogORM.event_type == "login_success").first()
+    assert log is not None
+    assert "password" not in log.details or log.details["password"] == "[REDACTED]"
+
+def test_logout_audit(db: Session):
+    email = "logout_audit@example.com"
+    password = "Password123!"
+    # Register and login
+    AuthStore.register(RegisterRequest(
+        email=email,
+        password=password,
+        full_name="Logout Audit",
+        role="engineer"
+    ), db=db)
+    session_resp = AuthStore.login(LoginRequest(email=email, password=password), db=db)
+    
+    # Logout
+    AuthStore.logout(session_resp.access_token, db=db)
+    
+    # Check audit log
+    log = db.query(AuditLogORM).filter(AuditLogORM.email == email, AuditLogORM.event_type == "logout").first()
+    assert log is not None
+
+def test_audit_redaction(db: Session):
+    from app.services.audit_log import AuditLogService
+    
+    AuditLogService.log_event(
+        db, 
+        "test_event", 
+        email="test@leak.com", 
+        details={"password": "secret_pass", "token": "sensitive_token", "safe": "data"}
+    )
+    
+    log = db.query(AuditLogORM).filter(AuditLogORM.email == "test@leak.com").first()
+    assert log.details["password"] == "[REDACTED]"
+    assert log.details["token"] == "[REDACTED]"
+    assert log.details["safe"] == "data"


### PR DESCRIPTION
I have implemented the requested tasks to enhance authentication, security, auditing, and operational filtering in the NOC-IQ backend.

Summary of Changes
1. Durable Authentication Layer & Secure Password Storage
ORM Models: Created UserORM and SessionORM in app/models/orm/ to persist users and sessions in the database, ensuring auth survives process restarts.
Repositories: Implemented UserRepository and SessionRepository to encapsulate database operations.
Password Security:
Integrated passlib with bcrypt for secure password hashing.
Added app/core/security.py with utilities for hashing, verification, and password policy enforcement.
Registration now enforces a policy (minimum 8 characters, uppercase, lowercase, digit, and special character).
AuthStore Refactor: Updated AuthStore to use the new persistence layer and security utilities while maintaining backward compatibility by supporting an optional database session.
API Endpoints: Updated app/api/v1/endpoints/auth.py to use dependency injection for the database session.
2. Structured Audit Logging
Audit Service: Created AuditLogService in app/services/audit_log.py which emits structured records to an audit_logs table.
Security: Implemented automatic redaction of sensitive fields (passwords, tokens) to prevent leaks in audit logs.
Integration: Added audit triggers for registration, successful/failed logins, token refreshes, and logouts.
Testing: Created tests/test_auth_audit.py with targeted tests for audit logging and redaction behavior.
3. Enhanced Outage Filtering
Search Functionality: Updated OutageRepository.list to support case-insensitive search across Outage ID, Site ID, and Site Name using SQLAlchemy ilike.
Date Range Filters: Added support for start_date and end_date filters on the detected_at field.
Stable Pagination: Enforced stable ordering by detected_at and id to ensure consistent results when paginating through filtered data.
API Extension: Updated the /outages/ GET endpoint to accept the new filtering parameters.

closes #136 
closes #137 
closes #140 
closes #141 