### PR TITLE
Implement outage sorting, idempotency, transitions, and dry-run import

### DIFF
--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -1,23 +1,25 @@
 import csv
 import io
 import json
+from datetime import datetime
 
-from fastapi import APIRouter, Depends, File, HTTPException, Response, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Response, UploadFile
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
+from app.models import BulkOutageCreate, Outage, OutageCreate, OutageUpdate
 from app.models.enums import OutageStatus, Severity
 from app.models.outage import PaginatedOutages, ResolveOutageRequest
-from app.models import BulkOutageCreate, Outage, OutageCreate, OutageUpdate
-from app.repositories.outage_repository import OutageRepository
+from app.models.outage_dto import OutageSortDirection, OutageSortField
+from app.models.webhook import WebhookEvent
 from app.repositories.outage_event_repository import OutageEventRepository
+from app.repositories.outage_repository import OutageRepository
 from app.repositories.payment_repository import PaymentRepository
 from app.repositories.sla_repository import SLARepository
 from app.services.audit_log import audit_log
 from app.services.contracts import SLAContractAdapter, translate_contract_result
 from app.services.webhook_service import trigger_sla_violation_webhooks
-from app.models.webhook import WebhookEvent
 from app.utils.exporter import export_outages
 
 router = APIRouter()
@@ -56,6 +58,14 @@ def list_outages(
     end_date: datetime | None = None,
     page: int = 1,
     page_size: int = 20,
+    sort_by: OutageSortField = Query(
+        default=OutageSortField.detected_at,
+        description="Supported sort fields: detected_at, site_name, severity, status, id",
+    ),
+    sort_direction: OutageSortDirection = Query(
+        default=OutageSortDirection.desc,
+        description="Sort direction: asc or desc. Default is desc.",
+    ),
     db: Session = Depends(get_db),
 ):
     repo = OutageRepository(db)
@@ -67,6 +77,8 @@ def list_outages(
         end_date=end_date,
         page=page,
         page_size=page_size,
+        sort_by=sort_by,
+        sort_direction=sort_direction,
     )
 
 
@@ -96,16 +108,23 @@ def create_outage(payload: OutageCreate, db: Session = Depends(get_db)):
 @router.post("/bulk", response_model=dict)
 def bulk_create_outages(payload: BulkOutageCreate, db: Session = Depends(get_db)):
     repo = OutageRepository(db)
-    created = repo.bulk_create(payload.outages)
+    try:
+        created = repo.bulk_create(payload.outages)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"count": len(created), "items": created}
 
 
 @router.post("/import", response_model=dict, summary="Bulk import outages from CSV or JSON file")
-async def import_outages(file: UploadFile = File(...), db: Session = Depends(get_db)):
+async def import_outages(
+    file: UploadFile = File(...),
+    dry_run: bool = Query(default=False, description="Validate rows without writing to the database"),
+    db: Session = Depends(get_db),
+):
     content = await file.read()
     filename = file.filename or ""
 
-    imported, skipped, errors = [], [], []
+    row_outcomes = []
 
     if filename.endswith(".json"):
         try:
@@ -124,16 +143,39 @@ async def import_outages(file: UploadFile = File(...), db: Session = Depends(get
         raise HTTPException(status_code=400, detail="Unsupported file format. Use .json or .csv")
 
     repo = OutageRepository(db)
+    persisted_count = 0
+
     for i, row in enumerate(rows):
         try:
             payload = OutageCreate(**row)
-            repo.create(payload)
-            imported.append(payload.id)
+            if dry_run:
+                duplicate = repo.check_duplicate(payload)
+                row_outcomes.append(
+                    {
+                        "row": i,
+                        "id": payload.id,
+                        "valid": True,
+                        "duplicate": bool(duplicate),
+                        "existing_id": duplicate.id if duplicate else None,
+                    }
+                )
+            else:
+                before = repo.get(payload.id)
+                created = repo.create(payload)
+                row_outcomes.append({"row": i, "id": payload.id, "valid": True, "persisted": True, "outage_id": created.id})
+                if before is None and created.id == payload.id:
+                    persisted_count += 1
         except Exception as exc:
-            skipped.append(i)
-            errors.append({"row": i, "error": str(exc)})
+            row_outcomes.append({"row": i, "valid": False, "error": str(exc)})
 
-    return {"imported": len(imported), "skipped": len(skipped), "errors": errors}
+    return {
+        "mode": "dry_run" if dry_run else "import",
+        "total_rows": len(rows),
+        "persisted": 0 if dry_run else persisted_count,
+        "validated": sum(1 for row in row_outcomes if row.get("valid")),
+        "errors": [row for row in row_outcomes if not row.get("valid")],
+        "rows": row_outcomes,
+    }
 
 
 @router.put("/{outage_id}", response_model=Outage)
@@ -143,7 +185,10 @@ def update_outage(outage_id: str, payload: OutageUpdate, db: Session = Depends(g
     if not existing:
         raise HTTPException(status_code=404, detail="Outage not found")
 
-    updated = repo.update(outage_id, payload)
+    try:
+        updated = repo.update(outage_id, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     OutageEventRepository(db).record(outage_id, "updated", payload.model_dump(exclude_unset=True, exclude_none=True))
     return updated
 
@@ -155,7 +200,10 @@ def patch_outage(outage_id: str, payload: OutageUpdate, db: Session = Depends(ge
     if not existing:
         raise HTTPException(status_code=404, detail="Outage not found")
 
-    updated = repo.update(outage_id, payload)
+    try:
+        updated = repo.update(outage_id, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     OutageEventRepository(db).record(outage_id, "patched", payload.model_dump(exclude_unset=True, exclude_none=True))
     return updated
 
@@ -174,7 +222,10 @@ def delete_outage(outage_id: str, db: Session = Depends(get_db)):
 @router.post("/{outage_id}/resolve")
 def resolve_outage(outage_id: str, payload: ResolveOutageRequest, db: Session = Depends(get_db)):
     repo = OutageRepository(db)
-    outage = repo.resolve(outage_id, payload.mttr_minutes)
+    try:
+        outage = repo.resolve(outage_id, payload.mttr_minutes)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not outage:
         raise HTTPException(status_code=404, detail="Outage not found")
 
@@ -193,9 +244,7 @@ def resolve_outage(outage_id: str, payload: ResolveOutageRequest, db: Session = 
     OutageEventRepository(db).record(outage_id, "sla_computed", {"status": stored_sla.status})
     payment_repo = PaymentRepository(db)
     payment = payment_repo.create_for_sla_result(outage.id, stored_sla)
-    webhook_event = (
-        WebhookEvent.SLA_VIOLATION if stored_sla.status == "violated" else WebhookEvent.SLA_RESOLVED
-    )
+    webhook_event = WebhookEvent.SLA_VIOLATION if stored_sla.status == "violated" else WebhookEvent.SLA_RESOLVED
     trigger_sla_violation_webhooks(
         db,
         sla_data={"outage_id": outage.id, "sla": stored_sla.model_dump(), "payment": payment.model_dump()},
@@ -227,9 +276,7 @@ def recompute_sla(outage_id: str, db: Session = Depends(get_db)):
     stored_sla = sla_repo.create_if_changed(sla)
     payment_repo = PaymentRepository(db)
     payment = payment_repo.create_for_sla_result(outage.id, stored_sla)
-    webhook_event = (
-        WebhookEvent.SLA_VIOLATION if stored_sla.status == "violated" else WebhookEvent.SLA_RESOLVED
-    )
+    webhook_event = WebhookEvent.SLA_VIOLATION if stored_sla.status == "violated" else WebhookEvent.SLA_RESOLVED
     trigger_sla_violation_webhooks(
         db,
         sla_data={"outage_id": outage.id, "sla": stored_sla.model_dump(), "payment": payment.model_dump()},

--- a/app/models/outage_dto.py
+++ b/app/models/outage_dto.py
@@ -1,11 +1,25 @@
 from datetime import datetime
+from enum import Enum
 from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 
-from app.models.enums import Severity, OutageStatus
+from app.models.enums import OutageStatus, Severity
 
 from .outage import Location
+
+
+class OutageSortField(str, Enum):
+    detected_at = "detected_at"
+    site_name = "site_name"
+    severity = "severity"
+    status = "status"
+    id = "id"
+
+
+class OutageSortDirection(str, Enum):
+    asc = "asc"
+    desc = "desc"
 
 
 class OutageCreate(BaseModel):

--- a/app/repositories/outage_repository.py
+++ b/app/repositories/outage_repository.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 from typing import List, Optional
 
-from sqlalchemy import or_
+from sqlalchemy import and_, asc, desc, or_
 from sqlalchemy.orm import Session
 
 from app.models.enums import OutageStatus, Severity
 from app.models.orm.outage import OutageORM
 from app.models.outage import Outage, Location, SLAStatus
-from app.models.outage_dto import OutageCreate, OutageUpdate
+from app.models.outage_dto import OutageCreate, OutageSortDirection, OutageSortField, OutageUpdate
 
 
 def _orm_to_pydantic(orm: OutageORM) -> Outage:
@@ -37,6 +37,12 @@ def _orm_to_pydantic(orm: OutageORM) -> Outage:
     )
 
 
+ALLOWED_STATUS_TRANSITIONS = {
+    OutageStatus.open.value: {OutageStatus.open.value, OutageStatus.resolved.value},
+    OutageStatus.resolved.value: {OutageStatus.resolved.value},
+}
+
+
 class OutageRepository:
     def __init__(self, db: Session):
         self.db = db
@@ -50,6 +56,8 @@ class OutageRepository:
         end_date: Optional[datetime] = None,
         page: int = 1,
         page_size: int = 20,
+        sort_by: OutageSortField = OutageSortField.detected_at,
+        sort_direction: OutageSortDirection = OutageSortDirection.desc,
     ) -> dict:
         query = self.db.query(OutageORM)
 
@@ -71,8 +79,9 @@ class OutageRepository:
         if end_date:
             query = query.filter(OutageORM.detected_at <= end_date)
 
-        # Ensure stable pagination
-        query = query.order_by(OutageORM.detected_at.desc(), OutageORM.id.asc())
+        sort_column = getattr(OutageORM, sort_by.value)
+        direction_fn = asc if sort_direction == OutageSortDirection.asc else desc
+        query = query.order_by(direction_fn(sort_column), OutageORM.id.asc())
 
         total = query.count()
         items = query.offset((page - 1) * page_size).limit(page_size).all()
@@ -82,6 +91,8 @@ class OutageRepository:
             "total": total,
             "page": page,
             "page_size": page_size,
+            "sort_by": sort_by.value,
+            "sort_direction": sort_direction.value,
         }
 
     def list_all(self) -> List[Outage]:
@@ -97,7 +108,58 @@ class OutageRepository:
     def get_orm(self, outage_id: str) -> Optional[OutageORM]:
         return self.db.query(OutageORM).filter(OutageORM.id == outage_id).first()
 
+    @staticmethod
+    def validate_status_transition(current_status: str, next_status: str) -> None:
+        allowed = ALLOWED_STATUS_TRANSITIONS.get(current_status, set())
+        if next_status not in allowed:
+            raise ValueError(f"Invalid status transition: {current_status} -> {next_status}")
+
+    def _find_duplicate_orm(self, payload: OutageCreate) -> Optional[OutageORM]:
+        query = self.db.query(OutageORM).filter(
+            and_(
+                OutageORM.site_name == payload.site_name,
+                OutageORM.detected_at == payload.detected_at,
+                OutageORM.description == payload.description,
+            )
+        )
+        if payload.site_id:
+            query = query.filter(OutageORM.site_id == payload.site_id)
+        return query.first()
+
+    @staticmethod
+    def _is_same_outage(orm: OutageORM, payload: OutageCreate) -> bool:
+        return (
+            orm.id == payload.id
+            and orm.site_name == payload.site_name
+            and orm.site_id == payload.site_id
+            and orm.severity == payload.severity.value
+            and orm.status == payload.status.value
+            and orm.detected_at == payload.detected_at
+            and orm.description == payload.description
+            and (orm.affected_services or []) == payload.affected_services
+            and orm.affected_subscribers == payload.affected_subscribers
+            and orm.assigned_to == payload.assigned_to
+            and orm.created_by == payload.created_by
+            and (orm.location or None) == (payload.location.model_dump() if payload.location else None)
+        )
+
+    def check_duplicate(self, payload: OutageCreate) -> Optional[Outage]:
+        existing_by_id = self.get_orm(payload.id)
+        if existing_by_id:
+            if self._is_same_outage(existing_by_id, payload):
+                return _orm_to_pydantic(existing_by_id)
+            raise ValueError(f"Outage with id '{payload.id}' already exists with different content")
+
+        duplicate = self._find_duplicate_orm(payload)
+        if duplicate:
+            return _orm_to_pydantic(duplicate)
+        return None
+
     def create(self, payload: OutageCreate) -> Outage:
+        existing = self.check_duplicate(payload)
+        if existing:
+            return existing
+
         location_data = payload.location.model_dump() if payload.location else None
         orm = OutageORM(
             id=payload.id,
@@ -119,29 +181,7 @@ class OutageRepository:
         return _orm_to_pydantic(orm)
 
     def bulk_create(self, outages: List[OutageCreate]) -> List[Outage]:
-        created = []
-        for payload in outages:
-            location_data = payload.location.model_dump() if payload.location else None
-            orm = OutageORM(
-                id=payload.id,
-                site_name=payload.site_name,
-                site_id=payload.site_id,
-                severity=payload.severity.value,
-                status=payload.status.value,
-                detected_at=payload.detected_at,
-                description=payload.description,
-                affected_services=payload.affected_services,
-                affected_subscribers=payload.affected_subscribers,
-                assigned_to=payload.assigned_to,
-                created_by=payload.created_by,
-                location=location_data,
-            )
-            self.db.add(orm)
-            created.append(orm)
-        self.db.commit()
-        for orm in created:
-            self.db.refresh(orm)
-        return [_orm_to_pydantic(o) for o in created]
+        return [self.create(payload) for payload in outages]
 
     def update(self, outage_id: str, payload: OutageUpdate) -> Optional[Outage]:
         orm = self.get_orm(outage_id)
@@ -149,6 +189,11 @@ class OutageRepository:
             return None
 
         update_data = payload.model_dump(exclude_unset=True)
+        if "status" in update_data and update_data["status"] is not None:
+            next_status = update_data["status"]
+            next_status_value = next_status.value if hasattr(next_status, "value") else str(next_status)
+            self.validate_status_transition(orm.status, next_status_value)
+
         for key, value in update_data.items():
             if key == "location" and value is not None:
                 setattr(orm, key, value if isinstance(value, dict) else value.model_dump())
@@ -173,6 +218,7 @@ class OutageRepository:
         if not orm:
             return None
 
+        self.validate_status_transition(orm.status, OutageStatus.resolved.value)
         orm.status = OutageStatus.resolved.value
         orm.mttr_minutes = mttr_minutes
         orm.resolved_at = datetime.utcnow()

--- a/tests/test_outage_lifecycle.py
+++ b/tests/test_outage_lifecycle.py
@@ -60,7 +60,7 @@ class OutageLifecycleTests(unittest.TestCase):
             def __init__(self, db):
                 self.db = db
 
-            def list(self, severity=None, status=None, page=1, page_size=20):
+            def list(self, severity=None, status=None, search=None, start_date=None, end_date=None, page=1, page_size=20, sort_by=None, sort_direction=None):
                 return {"items": [self_outage], "total": 1, "page": page, "page_size": page_size}
 
         self_outage = self.outage

--- a/tests/test_outage_rules.py
+++ b/tests/test_outage_rules.py
@@ -1,0 +1,12 @@
+import pytest
+
+from app.repositories.outage_repository import OutageRepository
+
+
+def test_status_transition_open_to_resolved_allowed():
+    OutageRepository.validate_status_transition("open", "resolved")
+
+
+def test_status_transition_resolved_to_open_disallowed():
+    with pytest.raises(ValueError, match="Invalid status transition"):
+        OutageRepository.validate_status_transition("resolved", "open")


### PR DESCRIPTION
### Description
- Add `OutageSortField` and `OutageSortDirection` enums and accept `sort_by`/`sort_direction` on the list endpoint and thread them to `OutageRepository.list` for stable ordering with an `id` tie-breaker.  
- Introduce `ALLOWED_STATUS_TRANSITIONS` and `validate_status_transition` in `OutageRepository` and enforce validation in `update`, `resolve`, and the endpoint update/patch/resolve handlers (returning `400` on invalid transitions).  
- Add duplicate detection and idempotency via `check_duplicate` used by `create` and `bulk_create` so identical records return existing objects and conflicting IDs raise `ValueError`.  
- Implement import `dry_run` mode that validates rows and reports row-level outcomes (`valid`, `duplicate`, `existing_id`) without persisting, and make the import flow report totals and errors.
- Closes #142
- Closes #143
- Closes #144
- Closes #145

### Testing
- Compiled modified modules with `python -m compileall` for the changed files and compilation succeeded.  
- Ran `PYTHONPATH=. pytest -q tests/test_outage_rules.py` which passed (`2 passed`).  
- Running the full test suite (`pytest -q`) in this environment failed during collection due to unrelated import/environment issues (an `ImportError` for `UTC` from `datetime` in `app/services/auth_store.py` and module path differences), so only the targeted tests above were exercised successfully.

------