### PR TITLE
fix: resolve BE-077, BE-078, BE-079, BE-080

### DIFF
--- a/app/api/v1/endpoints/wallets.py
+++ b/app/api/v1/endpoints/wallets.py
@@ -22,7 +22,10 @@ def create_wallet(payload: WalletCreateRequest):
 
 @router.post("/link", response_model=Wallet)
 def link_wallet(payload: WalletLinkRequest):
-    return WalletRegistry.link_wallet(payload)
+    try:
+        return WalletRegistry.link_wallet(payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
 
 
 @router.get("/ping")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -22,6 +22,9 @@ class Settings(BaseSettings):
     STELLAR_NETWORK: str = "testnet"
     CONTRACT_EXECUTION_MODE: str = "local_adapter"
     PAYMENT_WEBHOOK_SECRET: str = ""
+    PAYMENT_ASSET_CODE: str = "USDC"
+    PAYMENT_FROM_ADDRESS: str = "SYSTEM_POOL"
+    PAYMENT_TO_ADDRESS: str = "OUTAGE_SETTLEMENT"
 
     class Config:
         env_file = ".env"
@@ -88,6 +91,13 @@ def validate_critical_settings(config: Settings) -> None:
             errors.append(
                 "CELERY_RESULT_BACKEND must not be empty when CELERY_TASK_ALWAYS_EAGER is false."
             )
+
+    if not config.PAYMENT_ASSET_CODE.strip():
+        errors.append("PAYMENT_ASSET_CODE must not be empty.")
+    if not config.PAYMENT_FROM_ADDRESS.strip():
+        errors.append("PAYMENT_FROM_ADDRESS must not be empty.")
+    if not config.PAYMENT_TO_ADDRESS.strip():
+        errors.append("PAYMENT_TO_ADDRESS must not be empty.")
 
     if errors:
         raise ValueError("Invalid startup configuration:\n- " + "\n- ".join(errors))

--- a/app/models/orm/payment.py
+++ b/app/models/orm/payment.py
@@ -17,7 +17,7 @@ class PaymentTransactionORM(Base):
     to_address = Column(String(255), nullable=False)
     status = Column(String(50), nullable=False, default="pending", index=True)
     outage_id = Column(String, ForeignKey("outages.id", ondelete="SET NULL"), nullable=True, index=True)
-    sla_result_id = Column(Integer, ForeignKey("sla_results.id", ondelete="SET NULL"), nullable=True, index=True)
+    sla_result_id = Column(Integer, ForeignKey("sla_results.id", ondelete="SET NULL"), nullable=True, index=True, unique=True)
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     confirmed_at = Column(DateTime, nullable=True)
     retry_count = Column(Integer, nullable=False, default=0)

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -1,7 +1,11 @@
 from datetime import datetime
 from typing import Dict, Optional
+import re
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+
+_STELLAR_PUBLIC_KEY_RE = re.compile(r'^G[A-Z2-7]{55}$')
 
 
 class Wallet(BaseModel):
@@ -23,6 +27,15 @@ class WalletLinkRequest(BaseModel):
     public_key: str = Field(..., min_length=2)
     funded: bool = False
     trustline_ready: bool = False
+
+    @field_validator("public_key")
+    @classmethod
+    def validate_stellar_public_key(cls, v: str) -> str:
+        if not _STELLAR_PUBLIC_KEY_RE.match(v):
+            raise ValueError(
+                "public_key must be a valid Stellar public key (starts with G, 56 characters, base32 alphabet)"
+            )
+        return v
 
 
 class WalletCreateResponse(Wallet):

--- a/app/repositories/payment_repository.py
+++ b/app/repositories/payment_repository.py
@@ -8,6 +8,7 @@ from app.models.orm.audit_log import AuditLogORM
 from app.models.orm.payment import PaymentTransactionORM
 from app.models.payment import PaymentTransaction, validate_transition
 from app.models.sla import SLAResult
+from app.core.config import settings
 
 
 def _orm_to_pydantic(orm: PaymentTransactionORM) -> PaymentTransaction:
@@ -63,12 +64,14 @@ class PaymentRepository:
             return None
         return _orm_to_pydantic(orm)
 
-    def get_by_sla_result(self, sla_result_id: int) -> Optional[PaymentTransaction]:
-        orm = (
+    def get_by_sla_result(self, sla_result_id: int, for_update: bool = False) -> Optional[PaymentTransaction]:
+        query = (
             self.db.query(PaymentTransactionORM)
             .filter(PaymentTransactionORM.sla_result_id == sla_result_id)
-            .first()
         )
+        if for_update:
+            query = query.with_for_update()
+        orm = query.first()
         if not orm:
             return None
         return _orm_to_pydantic(orm)
@@ -130,7 +133,7 @@ class PaymentRepository:
         if sla_result.id is None:
             raise ValueError("SLA result id is required to generate a payment record")
 
-        existing = self.get_by_sla_result(sla_result.id)
+        existing = self.get_by_sla_result(sla_result.id, for_update=True)
         if existing:
             return existing
 
@@ -140,9 +143,9 @@ class PaymentRepository:
             transaction_hash=f"sla-{sla_result.id}-{sla_result.payment_type}",
             type=sla_result.payment_type,
             amount=normalized_amount,
-            asset_code="USDC",
-            from_address="SYSTEM_POOL",
-            to_address="OUTAGE_SETTLEMENT",
+            asset_code=settings.PAYMENT_ASSET_CODE,
+            from_address=settings.PAYMENT_FROM_ADDRESS,
+            to_address=settings.PAYMENT_TO_ADDRESS,
             status="pending",
             outage_id=outage_id,
             sla_result_id=sla_result.id,

--- a/app/services/wallet_registry.py
+++ b/app/services/wallet_registry.py
@@ -56,9 +56,20 @@ class WalletRegistry:
     @classmethod
     def link_wallet(cls, payload: WalletLinkRequest) -> Wallet:
         now = cls._now()
-        existing = cls._wallets_by_user.get(payload.user_id)
-        created_at = existing.created_at if existing else now
 
+        existing_by_user = cls._wallets_by_user.get(payload.user_id)
+        if existing_by_user and existing_by_user.public_key != payload.public_key:
+            raise ValueError(
+                f"User '{payload.user_id}' is already linked to a different wallet address."
+            )
+
+        existing_by_address = cls._wallets_by_address.get(payload.public_key)
+        if existing_by_address and existing_by_address.user_id != payload.user_id:
+            raise ValueError(
+                f"Address '{payload.public_key}' is already linked to a different user."
+            )
+
+        created_at = existing_by_user.created_at if existing_by_user else now
         wallet = Wallet(
             user_id=payload.user_id,
             public_key=payload.public_key,

--- a/tests/test_be_077_078_079_080.py
+++ b/tests/test_be_077_078_079_080.py
@@ -1,0 +1,214 @@
+"""
+Tests for:
+  BE-077 - Externalize asset code and settlement-address configuration
+  BE-078 - Duplicate-payment prevention under concurrent resolve paths
+  BE-079 - Wallet address format validation and normalization
+  BE-080 - Wallet link conflict handling
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from pydantic import ValidationError
+
+from app.core.config import Settings, validate_critical_settings
+from app.models.wallet import WalletLinkRequest
+from app.services.wallet_registry import WalletRegistry
+
+# Valid 56-char Stellar public key (G + 55 base32 chars A-Z2-7)
+VALID_STELLAR_KEY = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+VALID_STELLAR_KEY_2 = "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+
+
+# ---------------------------------------------------------------------------
+# BE-077: Externalize asset/settlement config
+# ---------------------------------------------------------------------------
+
+class TestBE077:
+    def test_default_payment_config_values(self):
+        s = Settings()
+        assert s.PAYMENT_ASSET_CODE == "USDC"
+        assert s.PAYMENT_FROM_ADDRESS == "SYSTEM_POOL"
+        assert s.PAYMENT_TO_ADDRESS == "OUTAGE_SETTLEMENT"
+
+    def test_payment_config_overridable(self):
+        s = Settings(
+            PAYMENT_ASSET_CODE="XLM",
+            PAYMENT_FROM_ADDRESS="CUSTOM_POOL",
+            PAYMENT_TO_ADDRESS="CUSTOM_SETTLEMENT",
+        )
+        assert s.PAYMENT_ASSET_CODE == "XLM"
+        assert s.PAYMENT_FROM_ADDRESS == "CUSTOM_POOL"
+        assert s.PAYMENT_TO_ADDRESS == "CUSTOM_SETTLEMENT"
+
+    def test_empty_payment_asset_code_fails_validation(self):
+        s = Settings(PAYMENT_ASSET_CODE="  ")
+        with pytest.raises(ValueError, match="PAYMENT_ASSET_CODE"):
+            validate_critical_settings(s)
+
+    def test_empty_payment_from_address_fails_validation(self):
+        s = Settings(PAYMENT_FROM_ADDRESS="  ")
+        with pytest.raises(ValueError, match="PAYMENT_FROM_ADDRESS"):
+            validate_critical_settings(s)
+
+    def test_empty_payment_to_address_fails_validation(self):
+        s = Settings(PAYMENT_TO_ADDRESS="  ")
+        with pytest.raises(ValueError, match="PAYMENT_TO_ADDRESS"):
+            validate_critical_settings(s)
+
+    def test_create_for_sla_result_uses_config(self):
+        from app.repositories.payment_repository import PaymentRepository
+        from app.models.sla import SLAResult
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.with_for_update.return_value.first.return_value = None
+
+        repo = PaymentRepository(db)
+        sla = SLAResult(
+            id=42,
+            outage_id="out-1",
+            status="violated",
+            mttr_minutes=30,
+            threshold_minutes=20,
+            amount=100,
+            payment_type="penalty",
+            rating="poor",
+        )
+
+        captured = {}
+
+        def fake_add(orm):
+            captured["asset_code"] = orm.asset_code
+            captured["from_address"] = orm.from_address
+            captured["to_address"] = orm.to_address
+
+        db.add.side_effect = fake_add
+        db.refresh.side_effect = lambda orm: None
+
+        with patch("app.repositories.payment_repository.settings") as mock_settings:
+            mock_settings.PAYMENT_ASSET_CODE = "USDC_TEST"
+            mock_settings.PAYMENT_FROM_ADDRESS = "POOL_TEST"
+            mock_settings.PAYMENT_TO_ADDRESS = "SETTLE_TEST"
+            try:
+                repo.create_for_sla_result("out-1", sla)
+            except Exception:
+                pass  # db mock may not fully support refresh
+
+        assert captured.get("asset_code") == "USDC_TEST"
+        assert captured.get("from_address") == "POOL_TEST"
+        assert captured.get("to_address") == "SETTLE_TEST"
+
+
+# ---------------------------------------------------------------------------
+# BE-078: Duplicate-payment prevention
+# ---------------------------------------------------------------------------
+
+class TestBE078:
+    def test_unique_constraint_on_sla_result_id(self):
+        from app.models.orm.payment import PaymentTransactionORM
+        col = PaymentTransactionORM.__table__.c["sla_result_id"]
+        assert col.unique, "sla_result_id must have a unique constraint"
+
+    def test_get_by_sla_result_uses_for_update(self):
+        from app.repositories.payment_repository import PaymentRepository
+
+        db = MagicMock()
+        query_mock = MagicMock()
+        filter_mock = MagicMock()
+        for_update_mock = MagicMock()
+        for_update_mock.first.return_value = None
+
+        db.query.return_value = query_mock
+        query_mock.filter.return_value = filter_mock
+        filter_mock.with_for_update.return_value = for_update_mock
+
+        repo = PaymentRepository(db)
+        repo.get_by_sla_result(1, for_update=True)
+        filter_mock.with_for_update.assert_called_once()
+
+    def test_get_by_sla_result_no_lock_by_default(self):
+        from app.repositories.payment_repository import PaymentRepository
+
+        db = MagicMock()
+        query_mock = MagicMock()
+        filter_mock = MagicMock()
+        filter_mock.first.return_value = None
+
+        db.query.return_value = query_mock
+        query_mock.filter.return_value = filter_mock
+
+        repo = PaymentRepository(db)
+        repo.get_by_sla_result(1)
+        filter_mock.with_for_update.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# BE-079: Wallet address format validation
+# ---------------------------------------------------------------------------
+
+class TestBE079:
+    def test_valid_stellar_key_accepted(self):
+        req = WalletLinkRequest(user_id="u1", public_key=VALID_STELLAR_KEY)
+        assert req.public_key == VALID_STELLAR_KEY
+
+    def test_key_not_starting_with_G_rejected(self):
+        bad_key = "X" + "A" * 55
+        with pytest.raises(ValidationError, match="Stellar public key"):
+            WalletLinkRequest(user_id="u1", public_key=bad_key)
+
+    def test_key_wrong_length_rejected(self):
+        with pytest.raises(ValidationError):
+            WalletLinkRequest(user_id="u1", public_key="GSHORT")
+
+    def test_key_with_invalid_chars_rejected(self):
+        # 56 chars but contains '1' which is not in base32 alphabet (A-Z2-7)
+        bad_key = "G" + "1" * 55
+        with pytest.raises(ValidationError, match="Stellar public key"):
+            WalletLinkRequest(user_id="u1", public_key=bad_key)
+
+    def test_empty_key_rejected(self):
+        with pytest.raises(ValidationError):
+            WalletLinkRequest(user_id="u1", public_key="")
+
+
+# ---------------------------------------------------------------------------
+# BE-080: Wallet link conflict handling
+# ---------------------------------------------------------------------------
+
+class TestBE080:
+    def setup_method(self):
+        WalletRegistry._wallets_by_user.clear()
+        WalletRegistry._wallets_by_address.clear()
+
+    def test_link_new_wallet_succeeds(self):
+        req = WalletLinkRequest(user_id="user1", public_key=VALID_STELLAR_KEY)
+        wallet = WalletRegistry.link_wallet(req)
+        assert wallet.user_id == "user1"
+        assert wallet.public_key == VALID_STELLAR_KEY
+
+    def test_relink_same_user_same_address_succeeds(self):
+        req = WalletLinkRequest(user_id="user1", public_key=VALID_STELLAR_KEY)
+        WalletRegistry.link_wallet(req)
+        wallet = WalletRegistry.link_wallet(req)
+        assert wallet.public_key == VALID_STELLAR_KEY
+
+    def test_user_already_linked_to_different_address_raises(self):
+        WalletRegistry.link_wallet(WalletLinkRequest(user_id="user1", public_key=VALID_STELLAR_KEY))
+        with pytest.raises(ValueError, match="already linked to a different wallet address"):
+            WalletRegistry.link_wallet(WalletLinkRequest(user_id="user1", public_key=VALID_STELLAR_KEY_2))
+
+    def test_address_already_linked_to_different_user_raises(self):
+        WalletRegistry.link_wallet(WalletLinkRequest(user_id="user1", public_key=VALID_STELLAR_KEY))
+        with pytest.raises(ValueError, match="already linked to a different user"):
+            WalletRegistry.link_wallet(WalletLinkRequest(user_id="user2", public_key=VALID_STELLAR_KEY))
+
+    def test_link_wallet_endpoint_returns_409_on_conflict(self):
+        from fastapi.testclient import TestClient
+        from app.main import app
+
+        client = TestClient(app)
+        payload = {"user_id": "user1", "public_key": VALID_STELLAR_KEY}
+        client.post("/api/v1/wallets/link", json=payload)
+
+        # Link same address to different user → 409
+        conflict_payload = {"user_id": "user2", "public_key": VALID_STELLAR_KEY}
+        response = client.post("/api/v1/wallets/link", json=conflict_payload)
+        assert response.status_code == 409


### PR DESCRIPTION
## Summary

Resolves all four issues assigned to LaGodxy in a single PR.

---

### BE-077 — Externalize asset code and settlement-address configuration (closes #162)

- Added `PAYMENT_ASSET_CODE`, `PAYMENT_FROM_ADDRESS`, `PAYMENT_TO_ADDRESS` to `Settings` in `app/core/config.py` with sensible defaults
- Added startup validation: empty values fail fast with a clear error message
- Removed hardcoded `"USDC"`, `"SYSTEM_POOL"`, `"OUTAGE_SETTLEMENT"` from `payment_repository.create_for_sla_result`; now reads from `settings`

### BE-078 — Duplicate-payment prevention under concurrent resolve paths (closes #163)

- Added `unique=True` to `sla_result_id` column in `PaymentTransactionORM` — DB-level deduplication guarantee
- Added `for_update` parameter to `get_by_sla_result`; `create_for_sla_result` now acquires a `SELECT FOR UPDATE` lock before the existence check, closing the TOCTOU race window

### BE-079 — Wallet address format validation and normalization (closes #164)

- Added `_STELLAR_PUBLIC_KEY_RE = re.compile(r'^G[A-Z2-7]{55}$')` to `app/models/wallet.py`
- Added `@field_validator("public_key")` to `WalletLinkRequest`; malformed addresses fail fast with a descriptive error before any persistence or registry lookup

### BE-080 — Wallet link conflict handling (closes #165)

- `WalletRegistry.link_wallet` now checks both directions before writing:
  - if `user_id` is already mapped to a **different** address → `ValueError`
  - if `public_key` is already mapped to a **different** user → `ValueError`
- `/api/v1/wallets/link` endpoint catches `ValueError` and returns `HTTP 409 Conflict`

---

## Tests

Added `tests/test_be_077_078_079_080.py` with 19 tests covering all four issues (all passing).

## Files Changed

- `app/core/config.py`
- `app/repositories/payment_repository.py`
- `app/models/orm/payment.py`
- `app/models/wallet.py`
- `app/services/wallet_registry.py`
- `app/api/v1/endpoints/wallets.py`
- `tests/test_be_077_078_079_080.py` (new)