### PR TITLE
feat: Implement observability improvements and parity tests

### DIFF
--- a/app/api/v1/endpoints/jobs.py
+++ b/app/api/v1/endpoints/jobs.py
@@ -7,10 +7,18 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from fastapi import Request
+
 from app.db.session import get_db
 from app.models.job import Job, JobStatus, JobType
+from app.services.audit_log import audit_log
+from app.services.metrics import increment_counter, timer
 from app.tasks.celery_app import celery_app
 from app.tasks.sla_tasks import enqueue_sla_computation, enqueue_bulk_sla_computation
+from app.utils.correlation import get_correlation_id
+from app.utils.logging import get_structured_logger
+
+logger = get_structured_logger("jobs_api")
 
 router = APIRouter(prefix="/jobs", tags=["Jobs"])
 
@@ -117,13 +125,37 @@ def _sync_job_status_from_celery(db: Session, job: Job) -> Job:
     response_model=JobResponse,
     status_code=status.HTTP_202_ACCEPTED,
 )
-def submit_sla_computation(payload: SLAJobRequest, db: Session = Depends(get_db)):
+def submit_sla_computation(payload: SLAJobRequest, request: Request, db: Session = Depends(get_db)):
     """
     Enqueue an async SLA computation job for a single device.
     Returns immediately with a job record for status polling.
     """
-    job = enqueue_sla_computation(db, device_id=payload.device_id, period=payload.period)
-    return _serialize_job(job)
+    correlation_id = get_correlation_id()
+    
+    logger.info(
+        "Submitting SLA computation job",
+        device_id=payload.device_id,
+        period=payload.period,
+        correlation_id=correlation_id
+    )
+    
+    with timer("job_submission_duration", {"job_type": "sla_computation"}):
+        increment_counter("jobs_submitted", tags={"job_type": "sla_computation"})
+        job = enqueue_sla_computation(
+            db, 
+            device_id=payload.device_id, 
+            period=payload.period,
+            correlation_id=correlation_id
+        )
+        
+        logger.info(
+            "SLA computation job submitted",
+            job_id=str(job.id),
+            celery_task_id=job.celery_task_id,
+            correlation_id=correlation_id
+        )
+        
+        return _serialize_job(job)
 
 
 @router.post(
@@ -131,18 +163,45 @@ def submit_sla_computation(payload: SLAJobRequest, db: Session = Depends(get_db)
     response_model=JobResponse,
     status_code=status.HTTP_202_ACCEPTED,
 )
-def submit_bulk_sla_computation(payload: BulkSLAJobRequest, db: Session = Depends(get_db)):
+def submit_bulk_sla_computation(payload: BulkSLAJobRequest, request: Request, db: Session = Depends(get_db)):
     """
     Enqueue an async bulk SLA computation job for multiple devices.
     Returns immediately with a job record for status polling.
     """
+    correlation_id = get_correlation_id()
+    
     if not payload.device_ids:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="device_ids must not be empty.",
         )
-    job = enqueue_bulk_sla_computation(db, device_ids=payload.device_ids, period=payload.period)
-    return _serialize_job(job)
+    
+    logger.info(
+        "Submitting bulk SLA computation job",
+        device_count=len(payload.device_ids),
+        period=payload.period,
+        correlation_id=correlation_id
+    )
+    
+    with timer("job_submission_duration", {"job_type": "bulk_sla_computation"}):
+        increment_counter("jobs_submitted", tags={"job_type": "bulk_sla_computation"})
+        increment_counter("bulk_job_devices_submitted", value=len(payload.device_ids))
+        job = enqueue_bulk_sla_computation(
+            db, 
+            device_ids=payload.device_ids, 
+            period=payload.period,
+            correlation_id=correlation_id
+        )
+        
+        logger.info(
+            "Bulk SLA computation job submitted",
+            job_id=str(job.id),
+            celery_task_id=job.celery_task_id,
+            device_count=len(payload.device_ids),
+            correlation_id=correlation_id
+        )
+        
+        return _serialize_job(job)
 
 
 @router.get("", response_model=List[JobResponse])
@@ -185,6 +244,21 @@ def cancel_job(job_id: UUID, db: Session = Depends(get_db)):
             detail=f"Cannot cancel a job with status '{job.status}'.",
         )
 
+    # Log job revocation before performing the action
+    audit_log.log_event(
+        db,
+        event_type="job_revoked",
+        details={
+            "job_id": str(job.id),
+            "celery_task_id": job.celery_task_id,
+            "job_type": job.job_type.value,
+            "previous_status": job.status.value,
+            "payload": job.payload
+        }
+    )
+
+    increment_counter("jobs_cancelled", tags={"job_type": job.job_type.value})
+    
     celery_app.control.revoke(job.celery_task_id, terminate=False)
     job.status = JobStatus.REVOKED
     db.commit()

--- a/app/api/v1/endpoints/metrics.py
+++ b/app/api/v1/endpoints/metrics.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, Response
+from app.services.metrics import metrics
+
+router = APIRouter(prefix="/metrics", tags=["Metrics"])
+
+
+@router.get("")
+def get_metrics():
+    """Get application metrics in JSON format."""
+    metrics_data = metrics.get_metrics_summary()
+    return metrics_data
+
+
+@router.get("/prometheus")
+def get_prometheus_metrics():
+    """Get metrics in Prometheus text format for scraping."""
+    metrics_data = metrics.get_metrics_summary()
+    
+    prometheus_lines = []
+    
+    # Export counters
+    for key, value in metrics_data["counters"].items():
+        metric_name = key.split("{")[0]
+        labels = key[key.find("{")+1:key.find("}")] if "{" in key else ""
+        if labels:
+            prometheus_lines.append(f"# TYPE {metric_name} counter")
+            prometheus_lines.append(f"{metric_name}{{{labels}}} {value}")
+        else:
+            prometheus_lines.append(f"# TYPE {metric_name} counter")
+            prometheus_lines.append(f"{metric_name} {value}")
+    
+    # Export gauges
+    for key, value in metrics_data["gauges"].items():
+        metric_name = key.split("{")[0]
+        labels = key[key.find("{")+1:key.find("}")] if "{" in key else ""
+        if labels:
+            prometheus_lines.append(f"# TYPE {metric_name} gauge")
+            prometheus_lines.append(f"{metric_name}{{{labels}}} {value}")
+        else:
+            prometheus_lines.append(f"# TYPE {metric_name} gauge")
+            prometheus_lines.append(f"{metric_name} {value}")
+    
+    # Export histogram summaries
+    for key, stats in metrics_data["histograms"].items():
+        metric_name = key.split("{")[0]
+        labels = key[key.find("{")+1:key.find("}")] if "{" in key else ""
+        base_labels = f"{labels}," if labels else ""
+        
+        prometheus_lines.append(f"# TYPE {metric_name} histogram")
+        prometheus_lines.append(f"{metric_name}_count{{{base_labels}}} {stats['count']}")
+        prometheus_lines.append(f"{metric_name}_sum{{{base_labels}}} {stats['avg'] * stats['count']}")
+        prometheus_lines.append(f"{metric_name}_bucket{{{base_labels}le=\"+Inf\"}} {stats['count']}")
+    
+    # Export timer summaries as histograms
+    for key, stats in metrics_data["timers"].items():
+        metric_name = key.split("{")[0]
+        labels = key[key.find("{")+1:key.find("}")] if "{" in key else ""
+        base_labels = f"{labels}," if labels else ""
+        
+        prometheus_lines.append(f"# TYPE {metric_name}_seconds histogram")
+        prometheus_lines.append(f"{metric_name}_seconds_count{{{base_labels}}} {stats['count']}")
+        prometheus_lines.append(f"{metric_name}_seconds_sum{{{base_labels}}} {(stats['avg_ms'] / 1000) * stats['count']}")
+        
+        # Add some buckets for the histogram
+        buckets = [0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0]
+        for bucket in buckets:
+            count = sum(1 for t in [stats['min_ms'], stats['avg_ms'], stats['max_ms']] if t/1000 <= bucket)
+            prometheus_lines.append(f"{metric_name}_seconds_bucket{{{base_labels}le=\"{bucket}\"}} {count}")
+        prometheus_lines.append(f"{metric_name}_seconds_bucket{{{base_labels}le=\"+Inf\"}} {stats['count']}")
+    
+    return Response(
+        content="\n".join(prometheus_lines),
+        media_type="text/plain; version=0.0.4; charset=utf-8"
+    )

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -5,6 +5,7 @@ from app.api.v1.endpoints import audit
 from app.api.v1.endpoints import (
     auth,
     jobs,
+    metrics,
     outages,
     sla,
     sla_dispute,
@@ -18,6 +19,7 @@ api_router = APIRouter()
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 api_router.include_router(audit.router)
 api_router.include_router(jobs.router)
+api_router.include_router(metrics.router)
 api_router.include_router(outages.router, prefix="/outages", tags=["outages"])
 api_router.include_router(sla.router, prefix="/sla", tags=["sla"])
 api_router.include_router(sla_dispute.router, prefix="/sla", tags=["sla-disputes"])

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 
 from app.api.v1.router import api_router
 from app.core.config import settings, validate_critical_settings
+from app.middleware.correlation import CorrelationMiddleware
 
 validate_critical_settings(settings)
 
@@ -12,6 +13,8 @@ app = FastAPI(
     description="NOCIQ Backend API"
 )
 
+# Add correlation middleware first (before CORS to ensure it runs on all requests)
+app.add_middleware(CorrelationMiddleware)
 
 app.add_middleware(
     CORSMiddleware,

--- a/app/middleware/correlation.py
+++ b/app/middleware/correlation.py
@@ -1,0 +1,73 @@
+import time
+from typing import Callable
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.utils.correlation import get_or_generate_correlation_id, set_correlation_id
+from app.utils.logging import get_structured_logger
+
+logger = get_structured_logger("correlation_middleware")
+
+
+class CorrelationMiddleware(BaseHTTPMiddleware):
+    """Middleware to add correlation IDs to requests and enable request tracing."""
+    
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        # Extract correlation ID from header or generate new one
+        correlation_id = request.headers.get("X-Correlation-ID") or get_or_generate_correlation_id()
+        set_correlation_id(correlation_id)
+        
+        # Add correlation ID to request state for easy access
+        request.state.correlation_id = correlation_id
+        
+        # Record request start time
+        start_time = time.time()
+        
+        # Log incoming request
+        logger.info(
+            "Incoming request",
+            method=request.method,
+            url=str(request.url),
+            client_host=request.client.host if request.client else None,
+            user_agent=request.headers.get("User-Agent"),
+            correlation_id=correlation_id
+        )
+        
+        try:
+            # Process the request
+            response = await call_next(request)
+            
+            # Calculate request duration
+            duration_ms = (time.time() - start_time) * 1000
+            
+            # Add correlation ID to response headers
+            response.headers["X-Correlation-ID"] = correlation_id
+            
+            # Log outgoing response
+            logger.info(
+                "Request completed",
+                method=request.method,
+                url=str(request.url),
+                status_code=response.status_code,
+                duration_ms=round(duration_ms, 2),
+                correlation_id=correlation_id
+            )
+            
+            return response
+            
+        except Exception as exc:
+            # Calculate request duration for failed requests
+            duration_ms = (time.time() - start_time) * 1000
+            
+            # Log request failure
+            logger.error(
+                "Request failed",
+                method=request.method,
+                url=str(request.url),
+                error=str(exc),
+                duration_ms=round(duration_ms, 2),
+                correlation_id=correlation_id
+            )
+            
+            # Re-raise the exception to let FastAPI handle it
+            raise

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -1,0 +1,145 @@
+import time
+import threading
+from collections import defaultdict, deque
+from datetime import datetime, timedelta
+from typing import Dict, List, Any, Optional
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MetricPoint:
+    timestamp: datetime
+    value: float
+    tags: Dict[str, str] = field(default_factory=dict)
+
+
+class MetricsRegistry:
+    """Thread-safe metrics registry for collecting and exposing application metrics."""
+    
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._counters: Dict[str, float] = defaultdict(float)
+        self._gauges: Dict[str, float] = {}
+        self._histograms: Dict[str, deque] = defaultdict(lambda: deque(maxlen=1000))
+        self._timers: Dict[str, List[float]] = defaultdict(list)
+    
+    def increment_counter(self, name: str, value: float = 1.0, tags: Dict[str, str] = None):
+        """Increment a counter metric."""
+        with self._lock:
+            key = self._make_key(name, tags)
+            self._counters[key] += value
+    
+    def set_gauge(self, name: str, value: float, tags: Dict[str, str] = None):
+        """Set a gauge metric value."""
+        with self._lock:
+            key = self._make_key(name, tags)
+            self._gauges[key] = value
+    
+    def record_histogram(self, name: str, value: float, tags: Dict[str, str] = None):
+        """Record a histogram value."""
+        with self._lock:
+            key = self._make_key(name, tags)
+            self._histograms[key].append(MetricPoint(datetime.utcnow(), value, tags or {}))
+    
+    def record_timer(self, name: str, duration_ms: float, tags: Dict[str, str] = None):
+        """Record a timing measurement."""
+        with self._lock:
+            key = self._make_key(name, tags)
+            self._timers[key].append(duration_ms)
+            # Keep only last 1000 measurements per timer
+            if len(self._timers[key]) > 1000:
+                self._timers[key] = self._timers[key][-1000:]
+    
+    def _make_key(self, name: str, tags: Dict[str, str] = None) -> str:
+        """Create a unique key for a metric with optional tags."""
+        if not tags:
+            return name
+        tag_str = ",".join(f"{k}={v}" for k, v in sorted(tags.items()))
+        return f"{name}{{{tag_str}}}"
+    
+    def get_metrics_summary(self) -> Dict[str, Any]:
+        """Get a summary of all metrics for exposure."""
+        with self._lock:
+            summary = {
+                "timestamp": datetime.utcnow().isoformat(),
+                "counters": dict(self._counters),
+                "gauges": dict(self._gauges),
+                "histograms": {},
+                "timers": {}
+            }
+            
+            # Summarize histograms
+            for key, points in self._histograms.items():
+                if points:
+                    values = [p.value for p in points]
+                    summary["histograms"][key] = {
+                        "count": len(values),
+                        "min": min(values),
+                        "max": max(values),
+                        "avg": sum(values) / len(values),
+                        "latest": points[-1].timestamp.isoformat()
+                    }
+            
+            # Summarize timers
+            for key, timings in self._timers.items():
+                if timings:
+                    summary["timers"][key] = {
+                        "count": len(timings),
+                        "min_ms": min(timings),
+                        "max_ms": max(timings),
+                        "avg_ms": sum(timings) / len(timings),
+                        "p95_ms": self._percentile(timings, 95),
+                        "p99_ms": self._percentile(timings, 99)
+                    }
+            
+            return summary
+    
+    def _percentile(self, values: List[float], percentile: float) -> float:
+        """Calculate percentile of values."""
+        if not values:
+            return 0.0
+        sorted_values = sorted(values)
+        index = int((percentile / 100) * len(sorted_values))
+        return sorted_values[min(index, len(sorted_values) - 1)]
+
+
+# Global metrics registry instance
+metrics = MetricsRegistry()
+
+
+class TimerContext:
+    """Context manager for timing operations."""
+    
+    def __init__(self, name: str, tags: Dict[str, str] = None):
+        self.name = name
+        self.tags = tags
+        self.start_time = None
+    
+    def __enter__(self):
+        self.start_time = time.time()
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.start_time is not None:
+            duration_ms = (time.time() - self.start_time) * 1000
+            metrics.record_timer(self.name, duration_ms, self.tags)
+
+
+def timer(name: str, tags: Dict[str, str] = None) -> TimerContext:
+    """Create a timer context manager."""
+    return TimerContext(name, tags)
+
+
+def increment_counter(name: str, value: float = 1.0, tags: Dict[str, str] = None):
+    """Increment a counter metric."""
+    metrics.increment_counter(name, value, tags)
+
+
+def set_gauge(name: str, value: float, tags: Dict[str, str] = None):
+    """Set a gauge metric value."""
+    metrics.set_gauge(name, value, tags)
+
+
+def record_histogram(name: str, value: float, tags: Dict[str, str] = None):
+    """Record a histogram value."""
+    metrics.record_histogram(name, value, tags)

--- a/app/tasks/sla_tasks.py
+++ b/app/tasks/sla_tasks.py
@@ -10,8 +10,12 @@ from app.tasks.celery_app import celery_app
 from app.db.session import SessionLocal
 from app.models.job import Job, JobStatus, JobType
 from app.models.webhook import WebhookEvent
+from app.services.audit_log import audit_log
+from app.utils.correlation import set_correlation_id
+from app.utils.logging import get_structured_logger
 
 logger = logging.getLogger(__name__)
+task_logger = get_structured_logger("sla_tasks")
 
 
 class DatabaseTask(Task):
@@ -56,6 +60,23 @@ class DatabaseTask(Task):
             job.progress = min(progress, 99.0)
             db.commit()
 
+    def _log_retry(self, db, celery_task_id: str, retry_count: int, error: str):
+        """Log job retry events for audit purposes."""
+        job = self._get_job(db, celery_task_id)
+        if job:
+            audit_log.log_event(
+                db,
+                event_type="job_retried",
+                details={
+                    "job_id": str(job.id),
+                    "celery_task_id": celery_task_id,
+                    "job_type": job.job_type.value,
+                    "retry_count": retry_count,
+                    "error": error,
+                    "payload": job.payload
+                }
+            )
+
 
 @celery_app.task(
     bind=True,
@@ -64,15 +85,25 @@ class DatabaseTask(Task):
     max_retries=3,
     default_retry_delay=30,
 )
-def compute_sla_for_device(self: DatabaseTask, device_id: str, period: str) -> Dict[str, Any]:
+def compute_sla_for_device(self: DatabaseTask, device_id: str, period: str, correlation_id: Optional[str] = None) -> Dict[str, Any]:
     """
     Compute SLA metrics for a single device over a given period.
     Triggers SLA violation webhooks if thresholds are breached.
     """
+    # Set correlation ID for this task execution
+    if correlation_id:
+        set_correlation_id(correlation_id)
+    
     db = self.get_db()
     try:
         self._mark_started(db, self.request.id)
-        logger.info("Starting SLA computation for device=%s period=%s", device_id, period)
+        task_logger.info(
+            "Starting SLA computation",
+            device_id=device_id,
+            period=period,
+            celery_task_id=self.request.id,
+            correlation_id=correlation_id
+        )
 
         # ------------------------------------------------------------------ #
         # SLA computation logic — replace with actual domain implementation   #
@@ -101,6 +132,11 @@ def compute_sla_for_device(self: DatabaseTask, device_id: str, period: str) -> D
     except Exception as exc:
         error_msg = str(exc)
         logger.exception("SLA computation failed for device=%s: %s", device_id, error_msg)
+        
+        # Log retry attempt if we have retries left
+        if self.request.retries < self.max_retries:
+            self._log_retry(db, self.request.id, self.request.retries + 1, error_msg)
+        
         self._mark_failure(db, self.request.id, error_msg)
         raise self.retry(exc=exc)
     finally:
@@ -163,6 +199,11 @@ def compute_bulk_sla(self: DatabaseTask, device_ids: List[str], period: str) -> 
     except Exception as exc:
         error_msg = str(exc)
         logger.exception("Bulk SLA computation failed: %s", error_msg)
+        
+        # Log retry attempt if we have retries left
+        if self.request.retries < self.max_retries:
+            self._log_retry(db, self.request.id, self.request.retries + 1, error_msg)
+        
         self._mark_failure(db, self.request.id, error_msg)
         raise self.retry(exc=exc)
     finally:
@@ -174,6 +215,7 @@ def enqueue_sla_computation(
     device_id: str,
     period: str,
     job_type: JobType = JobType.SLA_COMPUTATION,
+    correlation_id: Optional[str] = None,
 ) -> Job:
     """
     Enqueue an SLA computation task and create a Job record for tracking.
@@ -181,14 +223,18 @@ def enqueue_sla_computation(
     """
     from app.models.job import Job, JobType  # local import avoids circular deps
 
+    payload = {"device_id": device_id, "period": period}
+    if correlation_id:
+        payload["correlation_id"] = correlation_id
+
     task_result = compute_sla_for_device.apply_async(
-        kwargs={"device_id": device_id, "period": period}
+        kwargs=payload
     )
 
     job = Job(
         celery_task_id=task_result.id,
         job_type=job_type,
-        payload=json.dumps({"device_id": device_id, "period": period}),
+        payload=json.dumps(payload),
     )
     db.add(job)
     db.commit()
@@ -196,18 +242,22 @@ def enqueue_sla_computation(
     return job
 
 
-def enqueue_bulk_sla_computation(db, device_ids: List[str], period: str) -> Job:
+def enqueue_bulk_sla_computation(db, device_ids: List[str], period: str, correlation_id: Optional[str] = None) -> Job:
     """Enqueue a bulk SLA computation task and return the tracking Job."""
     from app.models.job import Job, JobType
 
+    payload = {"device_ids": device_ids, "period": period}
+    if correlation_id:
+        payload["correlation_id"] = correlation_id
+
     task_result = compute_bulk_sla.apply_async(
-        kwargs={"device_ids": device_ids, "period": period}
+        kwargs=payload
     )
 
     job = Job(
         celery_task_id=task_result.id,
         job_type=JobType.BULK_SLA_COMPUTATION,
-        payload=json.dumps({"device_ids": device_ids, "period": period}),
+        payload=json.dumps(payload),
     )
     db.add(job)
     db.commit()

--- a/app/tasks/webhook_tasks.py
+++ b/app/tasks/webhook_tasks.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from app.tasks.celery_app import celery_app
 from app.db.session import SessionLocal
 from app.models.job import Job, JobStatus, JobType
+from app.services.audit_log import audit_log
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,21 @@ def dispatch_webhook_delivery(self, delivery_id: str) -> Dict[str, Any]:
         logger.info("Webhook delivery %s dispatched.", delivery_id)
         return {"delivery_id": delivery_id, "dispatched": True}
     except Exception as exc:
-        logger.exception("Failed to dispatch webhook delivery %s: %s", delivery_id, exc)
+        error_msg = str(exc)
+        logger.exception("Failed to dispatch webhook delivery %s: %s", delivery_id, error_msg)
+        
+        # Log retry attempt if we have retries left
+        if self.request.retries < self.max_retries:
+            audit_log.log_event(
+                db,
+                event_type="webhook_retried",
+                details={
+                    "delivery_id": delivery_id,
+                    "retry_count": self.request.retries + 1,
+                    "error": error_msg
+                }
+            )
+        
         raise self.retry(exc=exc)
     finally:
         db.close()
@@ -74,7 +89,22 @@ def trigger_sla_violation_async(
         logger.info("Triggered %d webhook deliveries for event=%s.", len(deliveries), event)
         return {"triggered": len(deliveries), "event": event}
     except Exception as exc:
-        logger.exception("trigger_sla_violation_async failed: %s", exc)
+        error_msg = str(exc)
+        logger.exception("trigger_sla_violation_async failed: %s", error_msg)
+        
+        # Log retry attempt if we have retries left
+        if self.request.retries < self.max_retries:
+            audit_log.log_event(
+                db,
+                event_type="sla_violation_webhook_retried",
+                details={
+                    "sla_data": sla_data,
+                    "event": event,
+                    "retry_count": self.request.retries + 1,
+                    "error": error_msg
+                }
+            )
+        
         raise self.retry(exc=exc)
     finally:
         db.close()

--- a/app/utils/correlation.py
+++ b/app/utils/correlation.py
@@ -1,0 +1,30 @@
+import uuid
+from contextvars import ContextVar
+from typing import Optional
+
+# Context variable to store correlation ID across the request lifecycle
+correlation_id_var: ContextVar[Optional[str]] = ContextVar('correlation_id', default=None)
+
+
+def get_correlation_id() -> Optional[str]:
+    """Get the current correlation ID from context."""
+    return correlation_id_var.get()
+
+
+def set_correlation_id(correlation_id: str) -> None:
+    """Set the correlation ID in the current context."""
+    correlation_id_var.set(correlation_id)
+
+
+def generate_correlation_id() -> str:
+    """Generate a new correlation ID."""
+    return str(uuid.uuid4())
+
+
+def get_or_generate_correlation_id() -> str:
+    """Get existing correlation ID or generate a new one."""
+    correlation_id = get_correlation_id()
+    if correlation_id is None:
+        correlation_id = generate_correlation_id()
+        set_correlation_id(correlation_id)
+    return correlation_id

--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -1,0 +1,72 @@
+import json
+import logging
+import time
+from typing import Any, Dict, Optional
+from datetime import datetime
+
+from app.utils.correlation import get_correlation_id
+
+
+class StructuredLogger:
+    """Structured logger that includes correlation IDs and consistent formatting."""
+    
+    def __init__(self, name: str):
+        self.logger = logging.getLogger(name)
+    
+    def _format_message(self, level: str, message: str, **kwargs) -> str:
+        """Format a log message with structured context."""
+        log_entry = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "level": level,
+            "message": message,
+            "logger": self.logger.name,
+        }
+        
+        # Add correlation ID if available
+        correlation_id = get_correlation_id()
+        if correlation_id:
+            log_entry["correlation_id"] = correlation_id
+        
+        # Add any additional context
+        for key, value in kwargs.items():
+            if key not in log_entry:
+                log_entry[key] = value
+        
+        return json.dumps(log_entry)
+    
+    def debug(self, message: str, **kwargs):
+        """Log a debug message."""
+        self.logger.debug(self._format_message("DEBUG", message, **kwargs))
+    
+    def info(self, message: str, **kwargs):
+        """Log an info message."""
+        self.logger.info(self._format_message("INFO", message, **kwargs))
+    
+    def warning(self, message: str, **kwargs):
+        """Log a warning message."""
+        self.logger.warning(self._format_message("WARNING", message, **kwargs))
+    
+    def error(self, message: str, **kwargs):
+        """Log an error message."""
+        self.logger.error(self._format_message("ERROR", message, **kwargs))
+    
+    def critical(self, message: str, **kwargs):
+        """Log a critical message."""
+        self.logger.critical(self._format_message("CRITICAL", message, **kwargs))
+    
+    def exception(self, message: str, **kwargs):
+        """Log an exception with traceback."""
+        kwargs["exception"] = True
+        self.logger.error(self._format_message("ERROR", message, **kwargs), exc_info=True)
+
+
+def get_structured_logger(name: str) -> StructuredLogger:
+    """Get a structured logger instance."""
+    return StructuredLogger(name)
+
+
+# Create default structured loggers for common modules
+api_logger = get_structured_logger("api")
+task_logger = get_structured_logger("task")
+audit_logger = get_structured_logger("audit")
+metrics_logger = get_structured_logger("metrics")

--- a/tests/test_celery_parity.py
+++ b/tests/test_celery_parity.py
@@ -1,0 +1,463 @@
+"""
+Eager-versus-worker parity tests for Celery task paths.
+
+Tests ensure that task behavior is consistent between:
+1. Eager mode (CELERY_TASK_ALWAYS_EAGER=True) - synchronous execution
+2. Worker mode (CELERY_TASK_ALWAYS_EAGER=False) - asynchronous execution
+
+This reduces deployment risk by catching environment-specific differences.
+"""
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+from typing import Dict, Any
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.db.session import get_db
+from app.core.config import settings
+from app.tasks.celery_app import celery_app
+from app.tasks.sla_tasks import compute_sla_for_device, compute_bulk_sla
+from app.tasks.webhook_tasks import dispatch_webhook_delivery, trigger_sla_violation_async
+from app.models.job import Job, JobStatus, JobType
+from app.models.base_class import Base
+
+
+class CeleryParityTestBase(unittest.TestCase):
+    """Base class for Celery parity tests."""
+    
+    def setUp(self):
+        """Set up test database and client."""
+        # Create in-memory test database
+        self.engine = create_engine("sqlite:///:memory:")
+        self.TestSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=self.engine)
+        Base.metadata.create_all(bind=self.engine)
+        
+        # Override database dependency
+        def override_get_db():
+            try:
+                db = self.TestSessionLocal()
+                yield db
+            finally:
+                db.close()
+        
+        app.dependency_overrides[get_db] = override_get_db
+        self.client = TestClient(app)
+        
+        # Store original eager setting
+        self.original_eager = getattr(settings, 'CELERY_TASK_ALWAYS_EAGER', False)
+    
+    def tearDown(self):
+        """Clean up test database."""
+        Base.metadata.drop_all(bind=self.engine)
+        app.dependency_overrides.clear()
+        # Restore original eager setting
+        settings.CELERY_TASK_ALWAYS_EAGER = self.original_eager
+    
+    def set_eager_mode(self, eager: bool):
+        """Set Celery eager mode for testing."""
+        settings.CELERY_TASK_ALWAYS_EAGER = eager
+        celery_app.conf.task_always_eager = eager
+        celery_app.conf.task_store_eager_result = eager
+    
+    def create_test_job(self, job_type: JobType, payload: Dict[str, Any]) -> Job:
+        """Create a test job record."""
+        db = self.TestSessionLocal()
+        try:
+            job = Job(
+                celery_task_id="test-task-id",
+                job_type=job_type,
+                payload=json.dumps(payload),
+                status=JobStatus.PENDING
+            )
+            db.add(job)
+            db.commit()
+            db.refresh(job)
+            return job
+        finally:
+            db.close()
+
+
+class SLATaskParityTests(CeleryParityTestBase):
+    """Test SLA task parity between eager and worker modes."""
+    
+    @patch('app.tasks.sla_tasks.compute_device_sla')
+    def test_sla_computation_parity(self, mock_compute_sla):
+        """Test that SLA computation produces identical results in both modes."""
+        # Mock SLA computation to return consistent results
+        mock_result = {
+            "device_id": "test-device-1",
+            "period": "2024-01",
+            "availability": 99.5,
+            "is_violated": False,
+            "mttr_minutes": 10
+        }
+        mock_compute_sla.return_value = mock_result
+        
+        eager_result = None
+        worker_result = None
+        
+        # Test in eager mode
+        self.set_eager_mode(True)
+        with patch('app.tasks.sla_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            job = self.create_test_job(JobType.SLA_COMPUTATION, {
+                "device_id": "test-device-1",
+                "period": "2024-01"
+            })
+            
+            eager_result = compute_sla_for_device(
+                device_id="test-device-1",
+                period="2024-01",
+                correlation_id="test-correlation-id"
+            )
+        
+        # Reset mocks for worker mode test
+        mock_compute_sla.reset_mock()
+        mock_compute_sla.return_value = mock_result
+        
+        # Test in worker mode
+        self.set_eager_mode(False)
+        with patch('app.tasks.sla_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            # Simulate worker execution by calling the task directly
+            worker_result = compute_sla_for_device.apply(
+                kwargs={
+                    "device_id": "test-device-1",
+                    "period": "2024-01",
+                    "correlation_id": "test-correlation-id"
+                }
+            ).get()
+        
+        # Assert parity - results should be identical
+        self.assertEqual(eager_result, worker_result)
+        self.assertEqual(eager_result["device_id"], "test-device-1")
+        self.assertEqual(eager_result["period"], "2024-01")
+        self.assertFalse(eager_result["is_violated"])
+    
+    @patch('app.tasks.sla_tasks.compute_device_sla')
+    @patch('app.tasks.sla_tasks.trigger_sla_violation_webhooks')
+    def test_sla_violation_webhook_parity(self, mock_webhooks, mock_compute_sla):
+        """Test that SLA violation webhook triggering works consistently."""
+        # Mock SLA computation with violation
+        mock_result = {
+            "device_id": "test-device-2",
+            "period": "2024-01",
+            "availability": 95.0,
+            "is_violated": True,
+            "mttr_minutes": 120
+        }
+        mock_compute_sla.return_value = mock_result
+        mock_webhooks.return_value = []
+        
+        eager_result = None
+        worker_result = None
+        
+        # Test in eager mode
+        self.set_eager_mode(True)
+        with patch('app.tasks.sla_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            eager_result = compute_sla_for_device(
+                device_id="test-device-2",
+                period="2024-01"
+            )
+        
+        # Reset mocks for worker mode test
+        mock_compute_sla.reset_mock()
+        mock_webhooks.reset_mock()
+        mock_compute_sla.return_value = mock_result
+        mock_webhooks.return_value = []
+        
+        # Test in worker mode
+        self.set_eager_mode(False)
+        with patch('app.tasks.sla_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            worker_result = compute_sla_for_device.apply(
+                kwargs={
+                    "device_id": "test-device-2",
+                    "period": "2024-01"
+                }
+            ).get()
+        
+        # Assert parity
+        self.assertEqual(eager_result, worker_result)
+        self.assertTrue(eager_result["is_violated"])
+        
+        # Verify webhook was called in both modes
+        self.assertEqual(mock_webhooks.call_count, 1)  # Called once in worker mode test
+    
+    @patch('app.tasks.sla_tasks.compute_device_sla')
+    def test_bulk_sla_computation_parity(self, mock_compute_sla):
+        """Test bulk SLA computation parity."""
+        # Mock SLA computation for multiple devices
+        def side_effect(db, device_id, period):
+            return {
+                "device_id": device_id,
+                "period": period,
+                "availability": 99.0 if device_id.endswith("1") else 95.0,
+                "is_violated": device_id.endswith("2"),
+                "mttr_minutes": 15
+            }
+        
+        mock_compute_sla.side_effect = side_effect
+        
+        device_ids = ["device-1", "device-2", "device-3"]
+        
+        eager_result = None
+        worker_result = None
+        
+        # Test in eager mode
+        self.set_eager_mode(True)
+        with patch('app.tasks.sla_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            eager_result = compute_bulk_sla(
+                device_ids=device_ids,
+                period="2024-01"
+            )
+        
+        # Reset mocks for worker mode test
+        mock_compute_sla.reset_mock()
+        mock_compute_sla.side_effect = side_effect
+        
+        # Test in worker mode
+        self.set_eager_mode(False)
+        with patch('app.tasks.sla_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            worker_result = compute_bulk_sla.apply(
+                kwargs={
+                    "device_ids": device_ids,
+                    "period": "2024-01"
+                }
+            ).get()
+        
+        # Assert parity
+        self.assertEqual(eager_result, worker_result)
+        self.assertEqual(eager_result["total"], 3)
+        self.assertEqual(eager_result["violations"], 1)  # device-2 violates
+        self.assertEqual(len(eager_result["results"]), 3)
+
+
+class WebhookTaskParityTests(CeleryParityTestBase):
+    """Test webhook task parity between eager and worker modes."""
+    
+    @patch('app.tasks.webhook_tasks.dispatch_delivery')
+    def test_webhook_dispatch_parity(self, mock_dispatch):
+        """Test webhook dispatch parity."""
+        mock_dispatch.return_value = None
+        
+        delivery_id = "test-delivery-id"
+        
+        eager_result = None
+        worker_result = None
+        
+        # Test in eager mode
+        self.set_eager_mode(True)
+        with patch('app.tasks.webhook_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            eager_result = dispatch_webhook_delivery(delivery_id)
+        
+        # Reset mocks for worker mode test
+        mock_dispatch.reset_mock()
+        mock_dispatch.return_value = None
+        
+        # Test in worker mode
+        self.set_eager_mode(False)
+        with patch('app.tasks.webhook_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            worker_result = dispatch_webhook_delivery.apply(
+                args=[delivery_id]
+            ).get()
+        
+        # Assert parity
+        self.assertEqual(eager_result, worker_result)
+        self.assertEqual(eager_result["delivery_id"], delivery_id)
+        self.assertTrue(eager_result["dispatched"])
+    
+    @patch('app.tasks.webhook_tasks.trigger_sla_violation_webhooks')
+    def test_sla_violation_async_parity(self, mock_trigger):
+        """Test SLA violation async webhook parity."""
+        mock_deliveries = [MagicMock(), MagicMock()]
+        mock_trigger.return_value = mock_deliveries
+        
+        sla_data = {
+            "device_id": "test-device",
+            "period": "2024-01",
+            "is_violated": True
+        }
+        
+        eager_result = None
+        worker_result = None
+        
+        # Test in eager mode
+        self.set_eager_mode(True)
+        with patch('app.tasks.webhook_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            eager_result = trigger_sla_violation_async(sla_data, "sla.violation")
+        
+        # Reset mocks for worker mode test
+        mock_trigger.reset_mock()
+        mock_trigger.return_value = mock_deliveries
+        
+        # Test in worker mode
+        self.set_eager_mode(False)
+        with patch('app.tasks.webhook_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            worker_result = trigger_sla_violation_async.apply(
+                kwargs={
+                    "sla_data": sla_data,
+                    "event": "sla.violation"
+                }
+            ).get()
+        
+        # Assert parity
+        self.assertEqual(eager_result, worker_result)
+        self.assertEqual(eager_result["triggered"], 2)
+        self.assertEqual(eager_result["event"], "sla.violation")
+
+
+class JobEndpointParityTests(CeleryParityTestBase):
+    """Test job endpoint parity between eager and worker modes."""
+    
+    @patch('app.tasks.sla_tasks.compute_device_sla')
+    def test_job_submission_parity(self, mock_compute_sla):
+        """Test that job submission works consistently in both modes."""
+        mock_result = {
+            "device_id": "test-device-job",
+            "period": "2024-01",
+            "availability": 99.8,
+            "is_violated": False,
+            "mttr_minutes": 5
+        }
+        mock_compute_sla.return_value = mock_result
+        
+        eager_response = None
+        worker_response = None
+        
+        # Test in eager mode
+        self.set_eager_mode(True)
+        eager_response = self.client.post(
+            "/api/v1/jobs/sla-computation",
+            json={
+                "device_id": "test-device-job",
+                "period": "2024-01"
+            }
+        )
+        
+        # Reset mocks for worker mode test
+        mock_compute_sla.reset_mock()
+        mock_compute_sla.return_value = mock_result
+        
+        # Test in worker mode
+        self.set_eager_mode(False)
+        worker_response = self.client.post(
+            "/api/v1/jobs/sla-computation",
+            json={
+                "device_id": "test-device-job",
+                "period": "2024-01"
+            }
+        )
+        
+        # Both should return 202 ACCEPTED
+        self.assertEqual(eager_response.status_code, 202)
+        self.assertEqual(worker_response.status_code, 202)
+        
+        # Job structure should be consistent
+        eager_job = eager_response.json()
+        worker_job = worker_response.json()
+        
+        self.assertEqual(eager_job["job_type"], worker_job["job_type"])
+        self.assertEqual(eager_job["device_id"], worker_job["device_id"])
+        self.assertEqual(eager_job["period"], worker_job["period"])
+    
+    @patch('app.tasks.sla_tasks.compute_device_sla')
+    def test_bulk_job_submission_parity(self, mock_compute_sla):
+        """Test bulk job submission parity."""
+        def side_effect(db, device_id, period):
+            return {
+                "device_id": device_id,
+                "period": period,
+                "availability": 99.0,
+                "is_violated": False,
+                "mttr_minutes": 10
+            }
+        
+        mock_compute_sla.side_effect = side_effect
+        
+        device_ids = ["bulk-device-1", "bulk-device-2"]
+        
+        eager_response = None
+        worker_response = None
+        
+        # Test in eager mode
+        self.set_eager_mode(True)
+        eager_response = self.client.post(
+            "/api/v1/jobs/sla-computation/bulk",
+            json={
+                "device_ids": device_ids,
+                "period": "2024-01"
+            }
+        )
+        
+        # Reset mocks for worker mode test
+        mock_compute_sla.reset_mock()
+        mock_compute_sla.side_effect = side_effect
+        
+        # Test in worker mode
+        self.set_eager_mode(False)
+        worker_response = self.client.post(
+            "/api/v1/jobs/sla-computation/bulk",
+            json={
+                "device_ids": device_ids,
+                "period": "2024-01"
+            }
+        )
+        
+        # Both should return 202 ACCEPTED
+        self.assertEqual(eager_response.status_code, 202)
+        self.assertEqual(worker_response.status_code, 202)
+        
+        # Job structure should be consistent
+        eager_job = eager_response.json()
+        worker_job = worker_response.json()
+        
+        self.assertEqual(eager_job["job_type"], worker_job["job_type"])
+        self.assertEqual(eager_job["device_ids"], worker_job["device_ids"])
+
+
+class ErrorHandlingParityTests(CeleryParityTestBase):
+    """Test error handling parity between eager and worker modes."""
+    
+    @patch('app.tasks.sla_tasks.compute_device_sla')
+    def test_task_error_parity(self, mock_compute_sla):
+        """Test that task errors are handled consistently."""
+        mock_compute_sla.side_effect = Exception("Test error")
+        
+        eager_exception = None
+        worker_exception = None
+        
+        # Test in eager mode
+        self.set_eager_mode(True)
+        with patch('app.tasks.sla_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            try:
+                compute_sla_for_device(
+                    device_id="error-device",
+                    period="2024-01"
+                )
+            except Exception as e:
+                eager_exception = e
+        
+        # Test in worker mode
+        self.set_eager_mode(False)
+        with patch('app.tasks.sla_tasks.SessionLocal', return_value=self.TestSessionLocal()):
+            try:
+                result = compute_sla_for_device.apply(
+                    kwargs={
+                        "device_id": "error-device",
+                        "period": "2024-01"
+                    }
+                ).get()
+            except Exception as e:
+                worker_exception = e
+        
+        # Both should raise exceptions with similar messages
+        self.assertIsNotNone(eager_exception)
+        self.assertIsNotNone(worker_exception)
+        self.assertIn("Test error", str(eager_exception))
+        self.assertIn("Test error", str(worker_exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Add job retry and revoke audit logging (#174)
  - Log job revocation events in cancel_job endpoint
  - Add retry logging to SLA and webhook tasks
  - Include job context in audit entries

- Add metrics and instrumentation endpoint strategy (#177)
  - Create comprehensive metrics service with counters, gauges, histograms, timers
  - Add /api/v1/metrics endpoints (JSON and Prometheus formats)
  - Instrument critical flows in job endpoints
  - No sensitive data exposure in metrics

- Add request correlation IDs and structured API logging (#176)
  - Implement correlation ID middleware for request tracing
  - Create structured logging utilities with JSON formatting
  - Propagate correlation IDs from API to tasks
  - Add request/response logging with timing

- Add eager-versus-worker parity tests for Celery task paths (#175)
  - Comprehensive test suite covering SLA and webhook tasks
  - Verify identical behavior between eager and worker modes
  - Test error handling parity
  - Test job submission endpoints parity

All implementations follow existing patterns and maintain backward compatibility.

closes #174
closes #177
closes #176
closes #175