### PR TITLE
feat: Implement BE-021, BE-027, BE-034, BE-042

### DIFF
--- a/alembic/versions/0011_sla_latest_uniqueness.py
+++ b/alembic/versions/0011_sla_latest_uniqueness.py
@@ -1,0 +1,32 @@
+"""Add partial unique index for latest SLA result per outage (BE-021).
+
+This migration enforces at the database level that there can be only ONE
+authoritative latest SLA result per outage at any time using a partial unique index.
+
+Revision ID: 0011_sla_latest_uniqueness
+Revises: 0010_wallet_persistence
+Create Date: 2026-04-28
+"""
+from alembic import op
+
+
+revision = "0011_sla_latest_uniqueness"
+down_revision = "0010_wallet_persistence"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create a partial unique index that enforces only ONE row per outage_id
+    # can have is_latest=True at any time
+    op.create_index(
+        "uq_sla_results_outage_latest",
+        "sla_results",
+        ["outage_id"],
+        unique=True,
+        postgresql_where="is_latest = true",  # Partial index: only applies when is_latest=True
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_sla_results_outage_latest", table_name="sla_results")

--- a/alembic/versions/0012_sla_latest_backfill.py
+++ b/alembic/versions/0012_sla_latest_backfill.py
@@ -1,0 +1,68 @@
+"""Backfill SLA results to ensure only one latest per outage (BE-021).
+
+This migration fixes any existing ambiguous rows where multiple SLA results
+for the same outage have is_latest=True. It keeps only the most recent one
+and demotes all others.
+
+Revision ID: 0012_sla_latest_backfill
+Revises: 0011_sla_latest_uniqueness
+Create Date: 2026-04-28
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0012_sla_latest_backfill"
+down_revision = "0011_sla_latest_uniqueness"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # This SQL finds duplicate is_latest=True rows per outage_id and keeps only
+    # the one with the highest id (most recent), demoting all others to is_latest=False
+    conn = op.get_bind()
+    
+    # First, identify outages with multiple is_latest=True rows
+    duplicates_query = """
+    SELECT outage_id, COUNT(*) as cnt
+    FROM sla_results
+    WHERE is_latest = true
+    GROUP BY outage_id
+    HAVING COUNT(*) > 1
+    """
+    
+    result = conn.execute(sa.text(duplicates_query))
+    duplicate_outages = result.fetchall()
+    
+    if duplicate_outages:
+        print(f"Found {len(duplicate_outages)} outages with duplicate is_latest=True rows")
+        
+        # For each duplicate outage, keep only the row with the highest id
+        for outage_id, count in duplicate_outages:
+            print(f"  Fixing outage {outage_id}: {count} duplicate latest rows")
+            
+            # Demote all except the one with the highest id
+            fix_query = """
+            UPDATE sla_results
+            SET is_latest = false
+            WHERE outage_id = :outage_id
+              AND is_latest = true
+              AND id NOT IN (
+                SELECT MAX(id)
+                FROM sla_results
+                WHERE outage_id = :outage_id
+                  AND is_latest = true
+              )
+            """
+            conn.execute(sa.text(fix_query), {"outage_id": outage_id})
+        
+        op.get_bind().commit()
+        print("Backfill complete: all outages now have at most one is_latest=True row")
+    else:
+        print("No duplicate is_latest=True rows found. Backfill not needed.")
+
+
+def downgrade() -> None:
+    # No-op: we don't want to re-introduce ambiguity
+    pass

--- a/alembic/versions/0013_webhook_secret_metadata.py
+++ b/alembic/versions/0013_webhook_secret_metadata.py
@@ -1,0 +1,34 @@
+"""Add webhook secret lifecycle metadata columns (BE-034).
+
+Adds tracking for secret rotation events including:
+- last_secret_rotation_at: timestamp of the most recent rotation
+- secret_version: incremented counter for each rotation
+
+Revision ID: 0013_webhook_secret_metadata
+Revises: 0012_sla_latest_backfill
+Create Date: 2026-04-28
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0013_webhook_secret_metadata"
+down_revision = "0012_sla_latest_backfill"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "webhooks",
+        sa.Column("last_secret_rotation_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "webhooks",
+        sa.Column("secret_version", sa.Integer(), nullable=False, server_default="1"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("webhooks", "secret_version")
+    op.drop_column("webhooks", "last_secret_rotation_at")

--- a/app/api/v1/endpoints/jobs.py
+++ b/app/api/v1/endpoints/jobs.py
@@ -16,7 +16,9 @@ from app.services.metrics import increment_counter, timer
 from app.tasks.celery_app import celery_app
 from app.tasks.sla_tasks import enqueue_sla_computation, enqueue_bulk_sla_computation
 from app.utils.correlation import get_correlation_id
+from app.utils.logging import get_structured_logger
 from app.core.security import require_engineer, require_admin
+from app.services.job_cleanup import JobCleanupService
 
 logger = get_structured_logger("jobs_api")
 
@@ -54,6 +56,32 @@ class JobResponse(BaseModel):
     created_at: str
 
     model_config = {"from_attributes": True}
+
+
+# BE-042: Job cleanup schemas
+class JobRetentionStatsResponse(BaseModel):
+    """Current job retention statistics."""
+    total_jobs: int
+    by_status: dict
+    by_age: dict
+
+
+class JobCleanupRequest(BaseModel):
+    """Request parameters for job cleanup."""
+    successful_retention_days: Optional[int] = None
+    failed_retention_days: Optional[int] = None
+    dry_run: bool = False
+
+
+class JobCleanupResponse(BaseModel):
+    """Response from job cleanup operation."""
+    successful_jobs_deleted: int
+    failed_jobs_deleted: int
+    revoked_jobs_deleted: int
+    total_deleted: int
+    cutoff_successful: str
+    cutoff_failed: str
+    dry_run: bool
 
 
 # --------------------------------------------------------------------------- #
@@ -298,3 +326,55 @@ def cancel_job(job_id: UUID, current_user=Depends(require_admin), db: Session = 
     celery_app.control.revoke(job.celery_task_id, terminate=False)
     job.status = JobStatus.REVOKED
     db.commit()
+
+
+# BE-042: Job retention and cleanup endpoints
+
+@router.get("/retention-stats", response_model=JobRetentionStatsResponse)
+def get_job_retention_stats(current_user=Depends(require_admin), db: Session = Depends(get_db)):
+    """Get current job retention statistics without deleting anything.
+    
+    BE-042: Provides visibility into job storage usage and aging.
+    """
+    cleanup_service = JobCleanupService(db)
+    return cleanup_service.get_retention_stats()
+
+
+@router.post("/cleanup", response_model=JobCleanupResponse)
+def cleanup_old_jobs(
+    payload: JobCleanupRequest,
+    current_user=Depends(require_admin),
+    db: Session = Depends(get_db)
+):
+    """Clean up old completed and failed jobs based on retention policy.
+    
+    BE-042: Removes old job records to prevent unbounded database growth.
+    - Successful/revoked jobs: default 30 day retention
+    - Failed jobs: default 90 day retention (preserved longer for debugging)
+    
+    Use dry_run=True to preview what would be deleted without actually deleting.
+    """
+    cleanup_service = JobCleanupService(db)
+    
+    result = cleanup_service.cleanup_old_jobs(
+        successful_retention_days=payload.successful_retention_days,
+        failed_retention_days=payload.failed_retention_days,
+        dry_run=payload.dry_run,
+    )
+    
+    # Log the cleanup operation
+    audit_log.log_event(
+        db,
+        event_type="job_cleanup_executed",
+        details={
+            "total_deleted": result["total_deleted"],
+            "successful_deleted": result["successful_jobs_deleted"],
+            "failed_deleted": result["failed_jobs_deleted"],
+            "revoked_deleted": result["revoked_jobs_deleted"],
+            "dry_run": payload.dry_run,
+            "executed_by": getattr(current_user, 'email', 'unknown'),
+        }
+    )
+    
+    return JobCleanupResponse(**result)
+

--- a/app/api/v1/endpoints/payments.py
+++ b/app/api/v1/endpoints/payments.py
@@ -17,6 +17,24 @@ from app.core.security import get_current_user, require_admin, require_engineer
 router = APIRouter()
 
 
+# BE-027: Schemas for reconciliation history
+class ReconciliationHistoryEntry(BaseModel):
+    """A single reconciliation history entry."""
+    event_type: str
+    actor: Optional[str] = None
+    previous_status: Optional[str] = None
+    new_status: str
+    timestamp: str
+    details: Optional[Dict[str, Any]] = None
+
+
+class ReconciliationHistoryResponse(BaseModel):
+    """Payment reconciliation history response."""
+    transaction_id: str
+    current_status: str
+    history: List[ReconciliationHistoryEntry]
+
+
 @router.get("/", response_model=PaginatedPayments)
 def list_payments(
     page: int = Query(default=1, ge=1),
@@ -57,6 +75,30 @@ def get_payment_history(transaction_id: str, current_user=Depends(require_engine
     return repo.get_payment_history(transaction_id)
 
 
+@router.get("/{transaction_id}/reconciliation-history", response_model=ReconciliationHistoryResponse)
+def get_payment_reconciliation_history(
+    transaction_id: str,
+    current_user=Depends(require_engineer),
+    db: Session = Depends(get_db)
+):
+    """Get detailed reconciliation history for a payment with timestamps and actor context.
+    
+    BE-027: Returns a stable, structured history suitable for frontend drawer or audit screen.
+    """
+    repo = PaymentRepository(db)
+    payment = repo.get(transaction_id)
+    if not payment:
+        raise HTTPException(status_code=404, detail="Payment not found")
+    
+    history = repo.get_reconciliation_history(transaction_id)
+    
+    return ReconciliationHistoryResponse(
+        transaction_id=transaction_id,
+        current_status=payment.status,
+        history=history,
+    )
+
+
 @router.get("/{transaction_id}", response_model=PaymentTransaction)
 def get_payment(transaction_id: str, current_user=Depends(require_engineer), db: Session = Depends(get_db)):
     repo = PaymentRepository(db)
@@ -78,13 +120,26 @@ def reconcile_payment(
     db: Session = Depends(get_db)
 ):
     repo = PaymentRepository(db)
+    existing = repo.get(transaction_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Payment not found")
+    
     try:
         payment = repo.reconcile(transaction_id, payload.status)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
     if not payment:
         raise HTTPException(status_code=404, detail="Payment not found")
-    audit_log.log("payment_reconciled", {"id": transaction_id, "status": payload.status})
+    
+    # BE-027: Include previous status in audit log for reconciliation history
+    audit_log.log(
+        "payment_reconciled",
+        {
+            "id": transaction_id,
+            "previous_status": existing.status,
+            "status": payload.status,
+        }
+    )
     return payment
 
 

--- a/app/api/v1/endpoints/webhooks.py
+++ b/app/api/v1/endpoints/webhooks.py
@@ -124,6 +124,9 @@ class WebhookResponse(BaseModel):
     events: List[str]
     max_retries: int
     schema_version: str = WEBHOOK_SCHEMA_VERSION  # BE-082: explicit schema version
+    # BE-034: Secret lifecycle metadata (without exposing the secret)
+    secret_version: int = 1
+    last_secret_rotation_at: Optional[str] = None
 
 
 class WebhookDeliveryResponse(BaseModel):
@@ -181,6 +184,8 @@ def _serialize_webhook(webhook: Webhook) -> WebhookResponse:
         is_active=webhook.is_active,
         events=events,
         max_retries=webhook.max_retries,
+        secret_version=webhook.secret_version,
+        last_secret_rotation_at=webhook.last_secret_rotation_at.isoformat() if webhook.last_secret_rotation_at else None,
     )
 
 
@@ -292,13 +297,46 @@ def list_webhook_deliveries(
 
 
 @router.post("/{webhook_id}/rotate-secret", response_model=WebhookSecretRotateResponse)  # BE-084
-def rotate_webhook_secret(webhook_id: UUID, db: Session = Depends(get_db)):
+def rotate_webhook_secret(
+    webhook_id: UUID,
+    current_user=Depends(require_admin),
+    db: Session = Depends(get_db)
+):
     """Rotate the webhook signing secret. The old secret is immediately invalidated;
-    all subsequent deliveries will be signed with the new secret."""
+    all subsequent deliveries will be signed with the new secret.
+    
+    BE-034: Emits durable audit information with timestamp and actor context.
+    """
+    from datetime import datetime
+    from app.services.audit_log import audit_log
+    
     webhook = _get_webhook_or_404(db, webhook_id)
+    
+    # Capture old metadata for audit trail
+    old_secret_version = webhook.secret_version
+    old_rotation_time = webhook.last_secret_rotation_at
+    
+    # Generate new secret and update metadata
     new_secret = secrets.token_hex(32)
     webhook.secret = new_secret
+    webhook.secret_version = old_secret_version + 1
+    webhook.last_secret_rotation_at = datetime.utcnow()
+    
     db.commit()
+    
+    # Emit audit log with actor context and timestamp
+    audit_log.log(
+        "webhook_secret_rotated",
+        {
+            "webhook_id": str(webhook_id),
+            "webhook_name": webhook.name,
+            "old_secret_version": old_secret_version,
+            "new_secret_version": webhook.secret_version,
+            "previous_rotation_at": old_rotation_time.isoformat() if old_rotation_time else None,
+            "rotated_by": getattr(current_user, 'email', 'unknown'),
+        }
+    )
+    
     return WebhookSecretRotateResponse(
         webhook_id=webhook.id,
         new_secret=new_secret,

--- a/app/models/webhook.py
+++ b/app/models/webhook.py
@@ -34,6 +34,10 @@ class Webhook(Base):
     max_retries = Column(Integer, default=3, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    
+    # BE-034: Secret lifecycle metadata
+    last_secret_rotation_at = Column(DateTime, nullable=True)  # When the secret was last rotated
+    secret_version = Column(Integer, default=1, nullable=False)  # Incremented on each rotation
 
     deliveries = relationship("WebhookDelivery", back_populates="webhook", cascade="all, delete-orphan")
 

--- a/app/repositories/payment_repository.py
+++ b/app/repositories/payment_repository.py
@@ -214,3 +214,39 @@ class PaymentRepository:
             for r in rows
             if r.details and r.details.get("id") == transaction_id
         ]
+
+    def get_reconciliation_history(self, transaction_id: str) -> List[dict]:
+        """Return detailed reconciliation history with actor context and status transitions.
+        
+        BE-027: Provides a structured view of who changed what and why, suitable for
+        audit screens and frontend drawers.
+        """
+        rows = (
+            self.db.query(AuditLogORM)
+            .filter(
+                AuditLogORM.event_type.in_(self.HISTORY_EVENT_TYPES),
+            )
+            .order_by(AuditLogORM.created_at.asc())
+            .all()
+        )
+        
+        history = []
+        for r in rows:
+            if r.details and r.details.get("id") == transaction_id:
+                # Extract previous and new status from details
+                previous_status = r.details.get("previous_status")
+                new_status = r.details.get("status") or r.details.get("new_status")
+                
+                history.append({
+                    "event_type": r.event_type,
+                    "actor": r.email,
+                    "previous_status": previous_status,
+                    "new_status": new_status,
+                    "timestamp": r.created_at.isoformat() if r.created_at else None,
+                    "details": {
+                        k: v for k, v in r.details.items() 
+                        if k not in {"previous_status", "status", "new_status", "id"}
+                    } or None,
+                })
+        
+        return history

--- a/app/repositories/sla_repository.py
+++ b/app/repositories/sla_repository.py
@@ -37,13 +37,23 @@ class SLARepository:
         else:
             payload = dict(sla_data)
 
-        # Demote any existing latest record for this outage (#154)
-        self.db.execute(
-            update(SLAResultORM)
-            .where(SLAResultORM.outage_id == payload["outage_id"])
-            .where(SLAResultORM.is_latest.is_(True))
-            .values(is_latest=False)
+        # Use row-level locking to prevent race conditions when updating latest flag
+        # First, lock any existing latest row for this outage
+        existing_latest = (
+            self.db.query(SLAResultORM)
+            .filter(SLAResultORM.outage_id == payload["outage_id"], SLAResultORM.is_latest.is_(True))
+            .with_for_update(nowait=False)
+            .first()
         )
+
+        # Demote any existing latest record for this outage (#154, #219)
+        if existing_latest:
+            self.db.execute(
+                update(SLAResultORM)
+                .where(SLAResultORM.outage_id == payload["outage_id"])
+                .where(SLAResultORM.is_latest.is_(True))
+                .values(is_latest=False)
+            )
 
         orm = SLAResultORM(
             outage_id=payload["outage_id"],

--- a/app/services/job_cleanup.py
+++ b/app/services/job_cleanup.py
@@ -1,0 +1,190 @@
+"""Job retention and cleanup service.
+
+BE-042: Provides job retention and cleanup policies to prevent unbounded growth
+of job records and maintain database performance.
+"""
+from datetime import datetime, timedelta
+from typing import Optional
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from app.models.job import Job, JobStatus
+
+
+class JobCleanupService:
+    """Manages job retention and cleanup policies."""
+    
+    # Default retention periods
+    SUCCESSFUL_JOB_RETENTION_DAYS = 30  # Keep successful jobs for 30 days
+    FAILED_JOB_RETENTION_DAYS = 90      # Keep failed jobs for 90 days (for debugging)
+    
+    def __init__(self, db: Session):
+        self.db = db
+    
+    def cleanup_old_jobs(
+        self,
+        successful_retention_days: Optional[int] = None,
+        failed_retention_days: Optional[int] = None,
+        dry_run: bool = False,
+        batch_size: int = 1000,
+    ) -> dict:
+        """Clean up old completed and failed jobs based on retention policy.
+        
+        Args:
+            successful_retention_days: Days to keep successful jobs (default: 30)
+            failed_retention_days: Days to keep failed jobs (default: 90)
+            dry_run: If True, only count what would be deleted without deleting
+            batch_size: Process deletions in batches to avoid long-running transactions
+            
+        Returns:
+            Dictionary with cleanup statistics
+        """
+        successful_retention_days = successful_retention_days or self.SUCCESSFUL_JOB_RETENTION_DAYS
+        failed_retention_days = failed_retention_days or self.FAILED_JOB_RETENTION_DAYS
+        
+        cutoff_success = datetime.utcnow() - timedelta(days=successful_retention_days)
+        cutoff_failed = datetime.utcnow() - timedelta(days=failed_retention_days)
+        
+        total_deleted = 0
+        stats = {
+            "successful_jobs_deleted": 0,
+            "failed_jobs_deleted": 0,
+            "revoked_jobs_deleted": 0,
+            "cutoff_successful": cutoff_success.isoformat(),
+            "cutoff_failed": cutoff_failed.isoformat(),
+            "dry_run": dry_run,
+        }
+        
+        # Clean up old successful jobs
+        success_count = self._count_jobs_by_status(JobStatus.SUCCESS, cutoff_success)
+        stats["successful_jobs_deleted"] = success_count
+        
+        if not dry_run and success_count > 0:
+            deleted = self._delete_jobs_by_status(
+                JobStatus.SUCCESS, cutoff_success, batch_size
+            )
+            total_deleted += deleted
+            stats["successful_jobs_deleted"] = deleted
+        
+        # Clean up old failed jobs
+        failed_count = self._count_jobs_by_status(JobStatus.FAILURE, cutoff_failed)
+        stats["failed_jobs_deleted"] = failed_count
+        
+        if not dry_run and failed_count > 0:
+            deleted = self._delete_jobs_by_status(
+                JobStatus.FAILURE, cutoff_failed, batch_size
+            )
+            total_deleted += deleted
+            stats["failed_jobs_deleted"] = deleted
+        
+        # Clean up old revoked jobs (same retention as successful)
+        revoked_count = self._count_jobs_by_status(JobStatus.REVOKED, cutoff_success)
+        stats["revoked_jobs_deleted"] = revoked_count
+        
+        if not dry_run and revoked_count > 0:
+            deleted = self._delete_jobs_by_status(
+                JobStatus.REVOKED, cutoff_success, batch_size
+            )
+            total_deleted += deleted
+            stats["revoked_jobs_deleted"] = deleted
+        
+        stats["total_deleted"] = total_deleted
+        
+        return stats
+    
+    def _count_jobs_by_status(self, status: JobStatus, cutoff_date: datetime) -> int:
+        """Count jobs with given status older than cutoff date."""
+        return (
+            self.db.query(Job)
+            .filter(
+                Job.status == status,
+                Job.finished_at < cutoff_date,
+            )
+            .count()
+        )
+    
+    def _delete_jobs_by_status(
+        self,
+        status: JobStatus,
+        cutoff_date: datetime,
+        batch_size: int,
+    ) -> int:
+        """Delete jobs with given status older than cutoff date in batches."""
+        total_deleted = 0
+        
+        while True:
+            # Get a batch of job IDs to delete
+            job_ids = (
+                self.db.query(Job.id)
+                .filter(
+                    Job.status == status,
+                    Job.finished_at < cutoff_date,
+                )
+                .limit(batch_size)
+                .all()
+            )
+            
+            job_ids = [jid[0] for jid in job_ids]  # Extract UUIDs from results
+            
+            if not job_ids:
+                break
+            
+            # Delete the batch
+            delete_stmt = delete(Job).where(Job.id.in_(job_ids))
+            self.db.execute(delete_stmt)
+            self.db.commit()
+            
+            total_deleted += len(job_ids)
+            
+            # If we got fewer than batch_size, we're done
+            if len(job_ids) < batch_size:
+                break
+        
+        return total_deleted
+    
+    def get_retention_stats(self) -> dict:
+        """Get current job retention statistics without deleting anything."""
+        now = datetime.utcnow()
+        
+        # Count jobs by status and age
+        stats = {
+            "total_jobs": self.db.query(Job).count(),
+            "by_status": {},
+            "by_age": {
+                "older_than_30_days": 0,
+                "older_than_60_days": 0,
+                "older_than_90_days": 0,
+            }
+        }
+        
+        # Count by status
+        for status in JobStatus:
+            count = (
+                self.db.query(Job)
+                .filter(Job.status == status)
+                .count()
+            )
+            stats["by_status"][status.value] = count
+        
+        # Count by age
+        cutoff_30 = now - timedelta(days=30)
+        cutoff_60 = now - timedelta(days=60)
+        cutoff_90 = now - timedelta(days=90)
+        
+        stats["by_age"]["older_than_30_days"] = (
+            self.db.query(Job)
+            .filter(Job.created_at < cutoff_30)
+            .count()
+        )
+        stats["by_age"]["older_than_60_days"] = (
+            self.db.query(Job)
+            .filter(Job.created_at < cutoff_60)
+            .count()
+        )
+        stats["by_age"]["older_than_90_days"] = (
+            self.db.query(Job)
+            .filter(Job.created_at < cutoff_90)
+            .count()
+        )
+        
+        return stats

--- a/tests/test_be_021_027_034_042.py
+++ b/tests/test_be_021_027_034_042.py
@@ -1,0 +1,406 @@
+"""Tests for BE-021, BE-027, BE-034, BE-042 implementations.
+
+Covers:
+- BE-021: SLA result uniqueness and locking
+- BE-027: Payment reconciliation history
+- BE-034: Webhook secret rotation auditing
+- BE-042: Job retention and cleanup
+"""
+import json
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.job import Job, JobStatus, JobType
+from app.models.orm.audit_log import AuditLogORM
+from app.models.orm.sla import SLAResultORM
+from app.models.webhook import Webhook, WebhookEvent
+from app.repositories.sla_repository import SLARepository
+from app.repositories.payment_repository import PaymentRepository
+from app.services.job_cleanup import JobCleanupService
+
+
+# ============================================================================
+# BE-021: SLA Result Uniqueness and Locking Tests
+# ============================================================================
+
+class TestBE021SlaUniqueness:
+    """Test database-level uniqueness and locking for SLA results."""
+
+    def test_create_sla_result_sets_latest_flag(self, db_session: Session):
+        """Creating a new SLA result should set is_latest=True."""
+        repo = SLARepository(db_session)
+        
+        sla_data = {
+            "outage_id": "test-outage-001",
+            "status": "met",
+            "mttr_minutes": 30,
+            "threshold_minutes": 60,
+            "amount": 100.0,
+            "payment_type": "reward",
+            "rating": "excellent",
+        }
+        
+        result = repo.create(sla_data)
+        
+        assert result.outage_id == "test-outage-001"
+        assert result.status == "met"
+        
+        # Verify is_latest is True in database
+        orm = db_session.query(SLAResultORM).filter(
+            SLAResultORM.outage_id == "test-outage-001"
+        ).first()
+        assert orm.is_latest is True
+
+    def test_create_new_result_demotes_previous_latest(self, db_session: Session):
+        """Creating a new SLA result should demote the previous latest."""
+        repo = SLARepository(db_session)
+        
+        sla_data_1 = {
+            "outage_id": "test-outage-002",
+            "status": "met",
+            "mttr_minutes": 30,
+            "threshold_minutes": 60,
+            "amount": 100.0,
+            "payment_type": "reward",
+            "rating": "excellent",
+        }
+        
+        result_1 = repo.create(sla_data_1)
+        
+        # Create second result for same outage
+        sla_data_2 = sla_data_1.copy()
+        sla_data_2["mttr_minutes"] = 45
+        result_2 = repo.create(sla_data_2)
+        
+        # Verify only one is_latest=True per outage
+        latest_results = db_session.query(SLAResultORM).filter(
+            SLAResultORM.outage_id == "test-outage-002",
+            SLAResultORM.is_latest.is_(True)
+        ).all()
+        
+        assert len(latest_results) == 1
+        assert latest_results[0].id == result_2.id
+
+    def test_get_by_outage_returns_latest(self, db_session: Session):
+        """get_by_outage should return the result with is_latest=True."""
+        repo = SLARepository(db_session)
+        
+        # Create multiple results
+        sla_data_1 = {
+            "outage_id": "test-outage-003",
+            "status": "met",
+            "mttr_minutes": 30,
+            "threshold_minutes": 60,
+            "amount": 100.0,
+            "payment_type": "reward",
+            "rating": "excellent",
+        }
+        
+        repo.create(sla_data_1)
+        
+        sla_data_2 = sla_data_1.copy()
+        sla_data_2["status"] = "violated"
+        sla_data_2["mttr_minutes"] = 90
+        repo.create(sla_data_2)
+        
+        # Should return the latest one
+        latest = repo.get_by_outage("test-outage-003")
+        
+        assert latest is not None
+        assert latest.status == "violated"
+        assert latest.mttr_minutes == 90
+
+
+# ============================================================================
+# BE-027: Payment Reconciliation History Tests
+# ============================================================================
+
+class TestBE027PaymentReconciliationHistory:
+    """Test payment reconciliation history endpoint."""
+
+    def test_reconciliation_history_empty(self, db_session: Session):
+        """New payment should have empty reconciliation history."""
+        from app.models.payment import PaymentTransaction
+        from app.models.orm.payment import PaymentTransactionORM
+        
+        # Create a test payment
+        payment_orm = PaymentTransactionORM(
+            id="test-pay-001",
+            transaction_hash="test-hash-001",
+            type="reward",
+            amount=100.0,
+            asset_code="XLM",
+            from_address="from_addr",
+            to_address="to_addr",
+            status="pending",
+        )
+        db_session.add(payment_orm)
+        db_session.commit()
+        
+        repo = PaymentRepository(db_session)
+        history = repo.get_reconciliation_history("test-pay-001")
+        
+        assert history == []
+
+    def test_reconciliation_history_with_events(self, db_session: Session):
+        """Reconciliation history should show status transitions."""
+        from app.models.orm.payment import PaymentTransactionORM
+        
+        # Create a test payment
+        payment_orm = PaymentTransactionORM(
+            id="test-pay-002",
+            transaction_hash="test-hash-002",
+            type="reward",
+            amount=100.0,
+            asset_code="XLM",
+            from_address="from_addr",
+            to_address="to_addr",
+            status="confirmed",
+        )
+        db_session.add(payment_orm)
+        db_session.commit()
+        
+        # Add audit log entries
+        audit_1 = AuditLogORM(
+            event_type="payment_reconciled",
+            email="admin@example.com",
+            details={
+                "id": "test-pay-002",
+                "previous_status": "pending",
+                "status": "confirmed",
+            },
+            created_at=datetime.utcnow(),
+        )
+        db_session.add(audit_1)
+        db_session.commit()
+        
+        repo = PaymentRepository(db_session)
+        history = repo.get_reconciliation_history("test-pay-002")
+        
+        assert len(history) == 1
+        assert history[0]["event_type"] == "payment_reconciled"
+        assert history[0]["actor"] == "admin@example.com"
+        assert history[0]["previous_status"] == "pending"
+        assert history[0]["new_status"] == "confirmed"
+        assert history[0]["timestamp"] is not None
+
+
+# ============================================================================
+# BE-034: Webhook Secret Rotation Auditing Tests
+# ============================================================================
+
+class TestBE034WebhookSecretRotation:
+    """Test webhook secret rotation auditing and metadata."""
+
+    def test_webhook_has_secret_metadata_fields(self, db_session: Session):
+        """Webhook model should have secret_version and last_secret_rotation_at."""
+        webhook = Webhook(
+            name="test-webhook",
+            url="https://example.com/webhook",
+            secret="initial-secret",
+            events=json.dumps(["sla.violation"]),
+        )
+        db_session.add(webhook)
+        db_session.commit()
+        db_session.refresh(webhook)
+        
+        assert webhook.secret_version == 1
+        assert webhook.last_secret_rotation_at is None
+
+    def test_secret_rotation_increments_version(self, db_session: Session):
+        """Rotating secret should increment version and set timestamp."""
+        from datetime import datetime
+        
+        webhook = Webhook(
+            name="test-webhook-rotate",
+            url="https://example.com/webhook",
+            secret="initial-secret",
+            events=json.dumps(["sla.violation"]),
+        )
+        db_session.add(webhook)
+        db_session.commit()
+        db_session.refresh(webhook)
+        
+        initial_version = webhook.secret_version
+        
+        # Simulate rotation
+        webhook.secret = "new-secret-value"
+        webhook.secret_version = initial_version + 1
+        webhook.last_secret_rotation_at = datetime.utcnow()
+        db_session.commit()
+        db_session.refresh(webhook)
+        
+        assert webhook.secret_version == 2
+        assert webhook.last_secret_rotation_at is not None
+        assert isinstance(webhook.last_secret_rotation_at, datetime)
+
+
+# ============================================================================
+# BE-042: Job Retention and Cleanup Tests
+# ============================================================================
+
+class TestBE042JobRetentionCleanup:
+    """Test job retention and cleanup policy."""
+
+    def test_cleanup_dry_run_does_not_delete(self, db_session: Session):
+        """Dry run cleanup should count but not delete jobs."""
+        # Create old successful jobs
+        old_date = datetime.utcnow() - timedelta(days=60)
+        
+        for i in range(5):
+            job = Job(
+                celery_task_id=f"task-dry-{i}",
+                job_type=JobType.SLA_COMPUTATION,
+                status=JobStatus.SUCCESS,
+                finished_at=old_date,
+                created_at=old_date,
+            )
+            db_session.add(job)
+        
+        db_session.commit()
+        
+        cleanup_service = JobCleanupService(db_session)
+        result = cleanup_service.cleanup_old_jobs(dry_run=True)
+        
+        assert result["total_deleted"] == 0
+        assert result["successful_jobs_deleted"] == 5
+        assert result["dry_run"] is True
+        
+        # Verify jobs still exist
+        count = db_session.query(Job).filter(
+            Job.celery_task_id.like("task-dry-%")
+        ).count()
+        assert count == 5
+
+    def test_cleanup_deletes_old_successful_jobs(self, db_session: Session):
+        """Cleanup should delete successful jobs older than retention period."""
+        old_date = datetime.utcnow() - timedelta(days=60)
+        
+        for i in range(3):
+            job = Job(
+                celery_task_id=f"task-old-success-{i}",
+                job_type=JobType.SLA_COMPUTATION,
+                status=JobStatus.SUCCESS,
+                finished_at=old_date,
+                created_at=old_date,
+            )
+            db_session.add(job)
+        
+        db_session.commit()
+        
+        cleanup_service = JobCleanupService(db_session)
+        result = cleanup_service.cleanup_old_jobs(
+            successful_retention_days=30,
+            dry_run=False,
+        )
+        
+        assert result["successful_jobs_deleted"] == 3
+        assert result["total_deleted"] == 3
+        
+        # Verify jobs are deleted
+        count = db_session.query(Job).filter(
+            Job.celery_task_id.like("task-old-success-%")
+        ).count()
+        assert count == 0
+
+    def test_cleanup_preserves_recent_failed_jobs(self, db_session: Session):
+        """Cleanup should preserve failed jobs within retention period."""
+        recent_date = datetime.utcnow() - timedelta(days=10)
+        
+        job = Job(
+            celery_task_id="task-recent-failed",
+            job_type=JobType.SLA_COMPUTATION,
+            status=JobStatus.FAILURE,
+            finished_at=recent_date,
+            created_at=recent_date,
+        )
+        db_session.add(job)
+        db_session.commit()
+        
+        cleanup_service = JobCleanupService(db_session)
+        result = cleanup_service.cleanup_old_jobs(
+            failed_retention_days=90,
+            dry_run=False,
+        )
+        
+        assert result["failed_jobs_deleted"] == 0
+        
+        # Verify job still exists
+        count = db_session.query(Job).filter(
+            Job.celery_task_id == "task-recent-failed"
+        ).count()
+        assert count == 1
+
+    def test_cleanup_deletes_old_failed_jobs(self, db_session: Session):
+        """Cleanup should delete failed jobs older than retention period."""
+        old_date = datetime.utcnow() - timedelta(days=120)
+        
+        job = Job(
+            celery_task_id="task-old-failed",
+            job_type=JobType.SLA_COMPUTATION,
+            status=JobStatus.FAILURE,
+            finished_at=old_date,
+            created_at=old_date,
+        )
+        db_session.add(job)
+        db_session.commit()
+        
+        cleanup_service = JobCleanupService(db_session)
+        result = cleanup_service.cleanup_old_jobs(
+            failed_retention_days=90,
+            dry_run=False,
+        )
+        
+        assert result["failed_jobs_deleted"] == 1
+        
+        # Verify job is deleted
+        count = db_session.query(Job).filter(
+            Job.celery_task_id == "task-old-failed"
+        ).count()
+        assert count == 0
+
+    def test_retention_stats_returns_correct_counts(self, db_session: Session):
+        """Retention stats should accurately count jobs by status and age."""
+        now = datetime.utcnow()
+        old_date = now - timedelta(days=45)
+        
+        # Create jobs with different statuses and ages
+        for i in range(3):
+            db_session.add(Job(
+                celery_task_id=f"task-recent-success-{i}",
+                job_type=JobType.SLA_COMPUTATION,
+                status=JobStatus.SUCCESS,
+                finished_at=now,
+                created_at=now,
+            ))
+        
+        for i in range(2):
+            db_session.add(Job(
+                celery_task_id=f"task-old-success-{i}",
+                job_type=JobType.SLA_COMPUTATION,
+                status=JobStatus.SUCCESS,
+                finished_at=old_date,
+                created_at=old_date,
+            ))
+        
+        db_session.commit()
+        
+        cleanup_service = JobCleanupService(db_session)
+        stats = cleanup_service.get_retention_stats()
+        
+        assert stats["total_jobs"] == 5
+        assert stats["by_status"]["success"] == 5
+        assert stats["by_age"]["older_than_30_days"] == 2
+
+
+# Pytest fixtures
+@pytest.fixture
+def db_session():
+    """Create a test database session."""
+    # This fixture should be provided by your test infrastructure
+    # Using conftest.py or similar
+    pass


### PR DESCRIPTION
Closes #219
BE-021: Add DB-level uniqueness and locking for SLA results
- Add partial unique index to enforce one latest result per outage
- Add row-level locking with SELECT FOR UPDATE in repository
- Create backfill migration for existing ambiguous rows

Closes #225
BE-027: Add payment reconciliation history endpoint
- Add GET /payments/{id}/reconciliation-history endpoint
- Include actor context, status transitions, and timestamps
- Enhanced audit logging with previous_status tracking

Closes #232
BE-034: Add webhook secret rotation auditing
- Add secret_version and last_secret_rotation_at metadata fields
- Emit durable audit logs with actor context on rotation
- Update WebhookResponse to expose lifecycle metadata (not secrets)

Closes #240
BE-042: Add job retention and cleanup policy
- Create JobCleanupService with configurable retention periods
- Add GET /jobs/retention-stats for visibility
- Add POST /jobs/cleanup with dry run support
- Batch deletion for safe, bounded cleanup operations

