### PR TITLE
Feat/import

### DIFF
--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -250,7 +250,7 @@ async def import_outages(
                     ))
             except Exception as exc:
                 row_outcomes.append(_row_error(i, row, exc))
-    elif atomic:
+    elif consistency == ImportConsistency.atomic:
         parsed: list[OutageCreate] = []
         for i, row in enumerate(rows):
             try:

--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -142,11 +142,17 @@ def create_outage(payload: OutageCreate, current_user=Depends(require_engineer),
 @router.post("/bulk", response_model=dict)
 def bulk_create_outages(payload: BulkOutageCreate, current_user=Depends(require_engineer), db: Session = Depends(get_db)):
     repo = OutageRepository(db)
+    items: list[Outage] = []
+    persisted_count = 0
     try:
-        created = repo.bulk_create(payload.outages)
+        for outage_payload in payload.outages:
+            created, persisted = repo.create_or_get_existing(outage_payload)
+            items.append(created)
+            if persisted:
+                persisted_count += 1
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return {"count": len(created), "items": created}
+    return {"count": len(items), "persisted": persisted_count, "items": items}
 
 
 @router.post("/import", response_model=ImportResponse, summary="Bulk import outages from CSV or JSON file with optional dry-run validation")
@@ -240,10 +246,14 @@ async def import_outages(
 
         try:
             for i, payload in enumerate(parsed):
-                created = repo.create(payload)
+                created, persisted = repo.create_or_get_existing(payload)
                 row_outcomes[i].outage_id = created.id
-                row_outcomes[i].persisted = True
-                persisted_count += 1
+                row_outcomes[i].persisted = persisted
+                if persisted:
+                    persisted_count += 1
+                else:
+                    row_outcomes[i].duplicate = True
+                    row_outcomes[i].existing_id = created.id
             db.commit()
         except Exception as exc:
             db.rollback()
@@ -252,12 +262,18 @@ async def import_outages(
         for i, row in enumerate(rows):
             try:
                 payload = OutageCreate(**row)
-                created = repo.create(payload)
+                created, persisted = repo.create_or_get_existing(payload)
                 row_outcomes.append(ImportRowResult(
-                    row=i, id=payload.id, status="ok",
-                    outage_id=created.id, persisted=True,
+                    row=i,
+                    id=payload.id,
+                    status="ok",
+                    outage_id=created.id,
+                    persisted=persisted,
+                    duplicate=not persisted,
+                    existing_id=created.id if not persisted else None,
                 ))
-                persisted_count += 1
+                if persisted:
+                    persisted_count += 1
             except Exception as exc:
                 db.rollback()
                 row_outcomes.append(_row_error(i, row, exc))

--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -296,11 +296,7 @@ async def import_outages(
                 db.rollback()
                 row_outcomes.append(_row_error(i, row, exc))
 
-return _import_response("dry_run" if dry_run else "import", consistency, len(rows), persisted_count, row_outcomes)
-
-
-# --- #215: helpers for machine-readable error output ---
-
+    return _import_response("dry_run" if dry_run else "import", consistency, len(rows), persisted_count, row_outcomes)
 def _row_error(index: int, raw_row: dict, exc: Exception) -> ImportRowResult:
     """Return a stable machine-readable ImportRowResult for a failed row."""
     errors: list[ImportFieldError] = []

--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -127,6 +127,8 @@ def get_outage(outage_id: str, current_user=Depends(require_engineer), db: Sessi
 
 @router.post("/", response_model=Outage)
 def create_outage(payload: OutageCreate, current_user=Depends(require_engineer), db: Session = Depends(get_db)):
+    # Creation is idempotent when the same outage payload is submitted again.
+    # Duplicate outage payloads are detected and the existing outage is returned.
     repo = OutageRepository(db)
     try:
         outage = repo.create(payload)
@@ -155,6 +157,9 @@ def bulk_create_outages(payload: BulkOutageCreate, current_user=Depends(require_
     return {"count": len(items), "persisted": persisted_count, "items": items}
 
 
+# Duplicate detection is explicit and consistent for imports:
+# - same site_name, detected_at, description, and optional site_id are treated as the same outage
+# - duplicate rows are reported as duplicate and do not create additional persisted rows
 @router.post("/import", response_model=ImportResponse, summary="Bulk import outages from CSV or JSON file with optional dry-run validation")
 async def import_outages(
     file: UploadFile = File(...),

--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -11,7 +11,14 @@ from app.db.session import get_db
 from app.models import BulkOutageCreate, Outage, OutageCreate, OutageUpdate
 from app.models.enums import OutageStatus, Severity
 from app.models.outage import PaginatedOutages, ResolveOutageRequest
-from app.models.outage_dto import OutageSortDirection, OutageSortField, ImportFieldError, ImportRowResult, ImportResponse
+from app.models.outage_dto import (
+    OutageSortDirection,
+    OutageSortField,
+    ImportConsistency,
+    ImportFieldError,
+    ImportRowResult,
+    ImportResponse,
+)
 from app.models.webhook import WebhookEvent
 from app.repositories.outage_event_repository import OutageEventRepository
 from app.repositories.outage_repository import OutageRepository
@@ -163,8 +170,14 @@ def bulk_create_outages(payload: BulkOutageCreate, current_user=Depends(require_
 @router.post("/import", response_model=ImportResponse, summary="Bulk import outages from CSV or JSON file with optional dry-run validation")
 async def import_outages(
     file: UploadFile = File(...),
-    dry_run: bool = Query(default=False, description="Validation-only mode: validate all rows WITHOUT persisting to database. Returns same field/row-level errors as live imports."),
-    atomic: bool = Query(default=True, description="All-or-nothing: rollback all writes if any row fails. Only applies when dry_run=false."),
+    dry_run: bool = Query(
+        default=False,
+        description="Validation-only mode: validate all rows WITHOUT persisting to database. Returns the same field/row-level errors as live imports.",
+    ),
+    consistency: ImportConsistency = Query(
+        default=ImportConsistency.atomic,
+        description="Write consistency mode for live imports. atomic=all-or-nothing, partial=persist valid rows and report row-level failures.",
+    ),
     current_user=Depends(require_engineer),
     db: Session = Depends(get_db),
 ):
@@ -247,7 +260,7 @@ async def import_outages(
                 row_outcomes.append(_row_error(i, row, exc))
 
         if any(r.status == "error" for r in row_outcomes):
-            return _import_response("import", len(rows), 0, row_outcomes)
+            return _import_response("import", consistency, len(rows), 0, row_outcomes)
 
         try:
             for i, payload in enumerate(parsed):
@@ -283,7 +296,7 @@ async def import_outages(
                 db.rollback()
                 row_outcomes.append(_row_error(i, row, exc))
 
-    return _import_response("dry_run" if dry_run else "import", len(rows), persisted_count, row_outcomes)
+return _import_response("dry_run" if dry_run else "import", consistency, len(rows), persisted_count, row_outcomes)
 
 
 # --- #215: helpers for machine-readable error output ---
@@ -304,10 +317,11 @@ def _row_error(index: int, raw_row: dict, exc: Exception) -> ImportRowResult:
     return ImportRowResult(row=index, id=raw_row.get("id"), status="error", errors=errors)
 
 
-def _import_response(mode: str, total: int, persisted: int, outcomes: list[ImportRowResult]) -> ImportResponse:
+def _import_response(mode: str, consistency: ImportConsistency, total: int, persisted: int, outcomes: list[ImportRowResult]) -> ImportResponse:
     error_rows = [r for r in outcomes if r.status == "error"]
     return ImportResponse(
         mode=mode,
+        consistency=consistency,
         total_rows=total,
         persisted=persisted,
         validated=sum(1 for r in outcomes if r.status == "ok"),

--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -167,7 +167,7 @@ def bulk_create_outages(payload: BulkOutageCreate, current_user=Depends(require_
 # Duplicate detection is explicit and consistent for imports:
 # - same site_name, detected_at, description, and optional site_id are treated as the same outage
 # - duplicate rows are reported as duplicate and do not create additional persisted rows
-@router.post("/import", response_model=ImportResponse, summary="Bulk import outages from CSV or JSON file with optional dry-run validation")
+@router.post("/import", response_model=ImportResponse, summary="Bulk import outages from CSV or JSON file with optional dry-run validation and explicit consistency mode")
 async def import_outages(
     file: UploadFile = File(...),
     dry_run: bool = Query(

--- a/app/api/v1/endpoints/webhooks.py
+++ b/app/api/v1/endpoints/webhooks.py
@@ -1,10 +1,12 @@
 import json
 import secrets
+from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, HttpUrl, field_validator
+from sqlalchemy import cast, func, or_, String
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
@@ -144,6 +146,15 @@ class WebhookDeliveryResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class PaginatedWebhookDeliveries(BaseModel):
+    items: List[WebhookDeliveryResponse]
+    total: int
+    offset: int
+    limit: int
+    returned: int
+    has_more: bool
+
+
 class WebhookSecretRotateResponse(BaseModel):
     webhook_id: UUID
     new_secret: str
@@ -277,23 +288,61 @@ def delete_webhook(webhook_id: UUID, current_user=Depends(require_admin), db: Se
     db.commit()
 
 
-@router.get("/{webhook_id}/deliveries", response_model=List[WebhookDeliveryResponse])
+@router.get("/{webhook_id}/deliveries", response_model=PaginatedWebhookDeliveries)
 def list_webhook_deliveries(
     webhook_id: UUID,
-    status_filter: Optional[WebhookDeliveryStatus] = Query(None, alias="status"),
+    status: Optional[WebhookDeliveryStatus] = Query(None, description="Filter by delivery status."),
+    event: Optional[WebhookEvent] = Query(None, description="Filter by delivery event type."),
+    search: Optional[str] = Query(None, description="Search delivery id, error message, or response status code."),
+    created_after: Optional[datetime] = Query(None, description="Return deliveries created after this timestamp."),
+    created_before: Optional[datetime] = Query(None, description="Return deliveries created before this timestamp."),
+    delivered_after: Optional[datetime] = Query(None, description="Return deliveries delivered after this timestamp."),
+    delivered_before: Optional[datetime] = Query(None, description="Return deliveries delivered before this timestamp."),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0, description="Number of records to skip"),  # BE-083
     db: Session = Depends(get_db),
 ):
     _get_webhook_or_404(db, webhook_id)
-    query = (
-        db.query(WebhookDelivery)
-        .filter(WebhookDelivery.webhook_id == webhook_id)
-        .order_by(WebhookDelivery.created_at.desc())
+    query = db.query(WebhookDelivery).filter(WebhookDelivery.webhook_id == webhook_id)
+
+    if status is not None:
+        query = query.filter(WebhookDelivery.status == status)
+    if event is not None:
+        query = query.filter(WebhookDelivery.event == event)
+    if created_after is not None:
+        query = query.filter(WebhookDelivery.created_at >= created_after)
+    if created_before is not None:
+        query = query.filter(WebhookDelivery.created_at <= created_before)
+    if delivered_after is not None:
+        query = query.filter(WebhookDelivery.delivered_at >= delivered_after)
+    if delivered_before is not None:
+        query = query.filter(WebhookDelivery.delivered_at <= delivered_before)
+    if search:
+        search_term = f"%{search}%"
+        query = query.filter(
+            or_(
+                cast(WebhookDelivery.id, String).ilike(search_term),
+                WebhookDelivery.error_message.ilike(search_term),
+                cast(WebhookDelivery.response_status_code, String).ilike(search_term),
+            )
+        )
+
+    total = query.order_by(None).count()
+    deliveries = (
+        query.order_by(WebhookDelivery.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
     )
-    if status_filter is not None:
-        query = query.filter(WebhookDelivery.status == status_filter)
-    return [_serialize_delivery(d) for d in query.offset(offset).limit(limit).all()]
+    items = [_serialize_delivery(d) for d in deliveries]
+    return PaginatedWebhookDeliveries(
+        items=items,
+        total=total,
+        offset=offset,
+        limit=limit,
+        returned=len(items),
+        has_more=offset + len(items) < total,
+    )
 
 
 @router.post("/{webhook_id}/rotate-secret", response_model=WebhookSecretRotateResponse)  # BE-084

--- a/app/models/outage_dto.py
+++ b/app/models/outage_dto.py
@@ -93,6 +93,11 @@ class OutageUpdate(BaseModel):
     location: Optional[Location] = None
 
 
+class ImportConsistency(str, Enum):
+    atomic = "atomic"
+    partial = "partial"
+
+
 class BulkOutageCreate(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
@@ -150,6 +155,7 @@ class ImportRowResult(BaseModel):
 class ImportResponse(BaseModel):
     """Top-level response for the import endpoint."""
     mode: str  # "dry_run" | "import"
+    consistency: ImportConsistency
     total_rows: int
     persisted: int
     validated: int

--- a/app/repositories/outage_repository.py
+++ b/app/repositories/outage_repository.py
@@ -193,10 +193,15 @@ class OutageRepository:
             return _orm_to_pydantic(duplicate)
         return None
 
-    def create(self, payload: OutageCreate) -> Outage:
+    def create_or_get_existing(self, payload: OutageCreate) -> tuple[Outage, bool]:
+        """Create a new outage or return an existing duplicate.
+
+        Returns a tuple of (outage, persisted).
+        Persisted is False when the payload matches an existing outage.
+        """
         existing = self.check_duplicate(payload)
         if existing:
-            return existing
+            return existing, False
 
         location_data = payload.location.model_dump() if payload.location else None
         orm = OutageORM(
@@ -216,7 +221,11 @@ class OutageRepository:
         self.db.add(orm)
         self.db.commit()
         self.db.refresh(orm)
-        return _orm_to_pydantic(orm)
+        return _orm_to_pydantic(orm), True
+
+    def create(self, payload: OutageCreate) -> Outage:
+        outage, _ = self.create_or_get_existing(payload)
+        return outage
 
     def bulk_create(self, outages: List[OutageCreate]) -> List[Outage]:
         return [self.create(payload) for payload in outages]

--- a/tests/test_stellar_wave_issues.py
+++ b/tests/test_stellar_wave_issues.py
@@ -88,6 +88,70 @@ out-1,Site A,critical,open,2026-01-01T10:00:00,Major outage,service1"""
         assert data["mode"] == "dry_run"
         assert any(r.get("duplicate") == True for r in data["rows"])
 
+    def test_import_reports_duplicate_rows_in_live_import(self, db: Session):
+        """Live import should report duplicate rows and not persist the duplicate."""
+        csv_content = b"""id,site_name,severity,status,detected_at,description,affected_services
+out-duplicate,Site A,critical,open,2026-01-01T10:00:00,Major outage,service1"""
+
+        response = client.post(
+            "/api/v1/outages/import",
+            files={"file": ("test.csv", csv_content, "text/csv")},
+            headers={"Authorization": "Bearer test-engineer-token"}
+        )
+        assert response.status_code == 200
+
+        response = client.post(
+            "/api/v1/outages/import",
+            files={"file": ("test.csv", csv_content, "text/csv")},
+            headers={"Authorization": "Bearer test-engineer-token"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["mode"] == "import"
+        assert data["total_rows"] == 1
+        assert data["persisted"] == 0
+        assert data["validated"] == 1
+        assert any(r.get("duplicate") == True for r in data["rows"])
+        assert data["rows"][0].get("existing_id") == "out-duplicate"
+
+    def test_bulk_create_reuses_existing_duplicates(self, db: Session):
+        """Bulk create should use the same duplicate detection rules and count persisted rows."""
+        payload = {
+            "outages": [
+                {
+                    "id": "out-bulk-1",
+                    "site_name": "Site B",
+                    "site_id": "site-B",
+                    "severity": "high",
+                    "status": "open",
+                    "detected_at": "2026-01-01T10:00:00",
+                    "description": "Bulk outage",
+                    "affected_services": ["service1"],
+                },
+                {
+                    "id": "out-bulk-1",
+                    "site_name": "Site B",
+                    "site_id": "site-B",
+                    "severity": "high",
+                    "status": "open",
+                    "detected_at": "2026-01-01T10:00:00",
+                    "description": "Bulk outage",
+                    "affected_services": ["service1"],
+                },
+            ]
+        }
+
+        response = client.post(
+            "/api/v1/outages/bulk",
+            json=payload,
+            headers={"Authorization": "Bearer test-engineer-token"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 2
+        assert data["persisted"] == 1
+        assert data["items"][0]["id"] == data["items"][1]["id"]
+
     def test_dry_run_does_not_persist(self, db: Session):
         """Dry-run mode should NOT persist outages to database."""
         csv_content = b"""id,site_name,severity,status,detected_at,description,affected_services

--- a/tests/test_stellar_wave_issues.py
+++ b/tests/test_stellar_wave_issues.py
@@ -108,11 +108,64 @@ out-duplicate,Site A,critical,open,2026-01-01T10:00:00,Major outage,service1"""
         assert response.status_code == 200
         data = response.json()
         assert data["mode"] == "import"
+        assert data["consistency"] == "atomic"
         assert data["total_rows"] == 1
         assert data["persisted"] == 0
         assert data["validated"] == 1
         assert any(r.get("duplicate") == True for r in data["rows"])
         assert data["rows"][0].get("existing_id") == "out-duplicate"
+
+    def test_import_atomic_rolls_back_all_rows_on_failure(self, db: Session):
+        """Atomic imports should rollback all writes if any row fails."""
+        csv_content = b"""id,site_name,severity,status,detected_at,description,affected_services
+out-atomic-1,Site A,critical,open,2026-01-01T10:00:00,Major outage,service1
+out-atomic-2,Site B,invalid_severity,open,2026-01-01T11:00:00,Minor outage,service2"""
+
+        response = client.post(
+            "/api/v1/outages/import?consistency=atomic",
+            files={"file": ("test.csv", csv_content, "text/csv")},
+            headers={"Authorization": "Bearer test-engineer-token"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["mode"] == "import"
+        assert data["consistency"] == "atomic"
+        assert data["total_rows"] == 2
+        assert data["persisted"] == 0
+        assert data["error_count"] == 1
+
+        response = client.get(
+            "/api/v1/outages/out-atomic-1",
+            headers={"Authorization": "Bearer test-engineer-token"}
+        )
+        assert response.status_code == 404
+
+    def test_import_partial_persists_valid_rows_on_failure(self, db: Session):
+        """Partial imports should persist valid rows and report failures for invalid rows."""
+        csv_content = b"""id,site_name,severity,status,detected_at,description,affected_services
+out-partial-1,Site A,critical,open,2026-01-01T10:00:00,Major outage,service1
+out-partial-2,Site B,invalid_severity,open,2026-01-01T11:00:00,Minor outage,service2"""
+
+        response = client.post(
+            "/api/v1/outages/import?consistency=partial",
+            files={"file": ("test.csv", csv_content, "text/csv")},
+            headers={"Authorization": "Bearer test-engineer-token"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["mode"] == "import"
+        assert data["consistency"] == "partial"
+        assert data["total_rows"] == 2
+        assert data["persisted"] == 1
+        assert data["error_count"] == 1
+        assert any(r.get("status") == "error" for r in data["rows"])
+        assert any(r.get("persisted") is True for r in data["rows"])
+
+        response = client.get(
+            "/api/v1/outages/out-partial-1",
+            headers={"Authorization": "Bearer test-engineer-token"}
+        )
+        assert response.status_code == 200
 
     def test_bulk_create_reuses_existing_duplicates(self, db: Session):
         """Bulk create should use the same duplicate detection rules and count persisted rows."""

--- a/tests/test_webhook_delivery_listing.py
+++ b/tests/test_webhook_delivery_listing.py
@@ -1,0 +1,131 @@
+from datetime import datetime, timedelta
+
+from app.models.webhook import Webhook, WebhookDelivery, WebhookDeliveryStatus, WebhookEvent
+
+
+def test_webhook_delivery_listing_supports_filters_and_total_count(client, db):
+    webhook = Webhook(
+        name="delivery-list-webhook",
+        url="https://example.com/webhook",
+        secret="secret",
+        events="[\"sla.violation\"]",
+    )
+    db.add(webhook)
+    db.commit()
+    db.refresh(webhook)
+
+    now = datetime.utcnow()
+    successful_delivery = WebhookDelivery(
+        webhook_id=webhook.id,
+        event=WebhookEvent.SLA_VIOLATION,
+        payload="{}",
+        status=WebhookDeliveryStatus.SUCCESS,
+        attempt_count=1,
+        response_status_code=200,
+        error_message=None,
+        delivered_at=now - timedelta(minutes=10),
+        created_at=now - timedelta(minutes=10),
+    )
+    failed_delivery = WebhookDelivery(
+        webhook_id=webhook.id,
+        event=WebhookEvent.SLA_VIOLATION,
+        payload="{}",
+        status=WebhookDeliveryStatus.FAILED,
+        attempt_count=3,
+        response_status_code=504,
+        error_message="Request timed out",
+        delivered_at=now - timedelta(minutes=5),
+        created_at=now - timedelta(minutes=5),
+    )
+    pending_delivery = WebhookDelivery(
+        webhook_id=webhook.id,
+        event=WebhookEvent.SLA_VIOLATION,
+        payload="{}",
+        status=WebhookDeliveryStatus.PENDING,
+        attempt_count=0,
+        response_status_code=None,
+        error_message=None,
+        delivered_at=None,
+        created_at=now - timedelta(minutes=1),
+    )
+    db.add_all([successful_delivery, failed_delivery, pending_delivery])
+    db.commit()
+
+    response = client.get(
+        f"/webhooks/{webhook.id}/deliveries",
+        params={
+            "status": "failed",
+            "event": "sla.violation",
+            "search": "timed out",
+            "delivered_after": (now - timedelta(minutes=6)).isoformat(),
+            "delivered_before": (now - timedelta(minutes=4)).isoformat(),
+            "limit": 10,
+            "offset": 0,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["limit"] == 10
+    assert data["offset"] == 0
+    assert data["returned"] == 1
+    assert data["has_more"] is False
+    assert data["items"][0]["status"] == "failed"
+    assert data["items"][0]["error_message"] == "Request timed out"
+
+
+def test_webhook_delivery_listing_pagination_metadata(client, db):
+    webhook = Webhook(
+        name="delivery-paging-webhook",
+        url="https://example.com/webhook",
+        secret="secret",
+        events="[\"sla.violation\"]",
+    )
+    db.add(webhook)
+    db.commit()
+    db.refresh(webhook)
+
+    base = datetime.utcnow()
+    deliveries = []
+    for i in range(3):
+        deliveries.append(
+            WebhookDelivery(
+                webhook_id=webhook.id,
+                event=WebhookEvent.SLA_VIOLATION,
+                payload="{}",
+                status=WebhookDeliveryStatus.FAILED,
+                attempt_count=i + 1,
+                response_status_code=500,
+                error_message=f"failure-{i}",
+                delivered_at=base - timedelta(minutes=i),
+                created_at=base - timedelta(minutes=i),
+            )
+        )
+    db.add_all(deliveries)
+    db.commit()
+
+    response = client.get(
+        f"/webhooks/{webhook.id}/deliveries",
+        params={"status": "failed", "limit": 1, "offset": 0},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 3
+    assert data["returned"] == 1
+    assert data["has_more"] is True
+    assert data["offset"] == 0
+    assert data["limit"] == 1
+
+    response_next = client.get(
+        f"/webhooks/{webhook.id}/deliveries",
+        params={"status": "failed", "limit": 1, "offset": 1},
+    )
+    assert response_next.status_code == 200
+    data_next = response_next.json()
+    assert data_next["total"] == 3
+    assert data_next["returned"] == 1
+    assert data_next["has_more"] is True
+    assert data_next["offset"] == 1
+    assert data_next["limit"] == 1
+    assert data_next["items"][0]["error_message"] == "failure-1"


### PR DESCRIPTION
## Summary

Implemented explicit duplicate detection across outage creation and imports.

### What changed

- outage_repository.py
  - Added `create_or_get_existing()` to distinguish new persistence from duplicate reuse.
  - Kept `create()` compatible, while exposing persisted metadata for bulk/import flows.

- outages.py
  - `POST /api/v1/outages/import`
    - Live imports now mark duplicate rows explicitly.
    - `persisted` is counted only for newly created rows.
    - Duplicate rows return `duplicate=true` and `existing_id`.
  - `POST /api/v1/outages/bulk`
    - Now uses the same duplicate detection behavior.
    - Returns `persisted` count alongside `count` and `items`.
  - Added comments documenting the import duplicate-detection strategy and idempotent create semantics.

- test_stellar_wave_issues.py
  - Added regression coverage for:
    - live import duplicate reporting
    - duplicate rows not persisting
    - bulk create duplicate reuse and persisted count handling

### Validation

- Static diagnostics on modified files reported no errors.

Made changes.

Closes #214 


## Update completed

### What changed

- outages.py
  - Replaced the old `atomic` boolean with explicit `consistency` query param.
  - Supported values: `atomic` (all-or-nothing) and `partial` (persist valid rows, report failures).
  - Response now includes `consistency` in `ImportResponse`.
  - Atomic mode returns `persisted=0` on any row-level validation failure.
  - Partial mode persists valid rows and reports invalid rows without rolling back prior successes.

Closes #234 

- outage_dto.py
  - Added `ImportConsistency` enum.
  - Extended `ImportResponse` with `consistency: ImportConsistency`.

- test_stellar_wave_issues.py
  - Added coverage for:
    - `consistency=atomic` rollback behavior on import failure.
    - `consistency=partial` partial-write behavior with valid row persistence.
    - response contract includes `consistency`.

### Validation

- Static diagnostics show no errors in the modified files.

Made changes.

Closes #216


## What changed

### Webhook delivery listing
- Updated webhooks.py
  - Added richer filters:
    - `status`
    - `event`
    - `search` (delivery id / error message / response status code)
    - `created_after`, `created_before`
    - `delivered_after`, `delivered_before`
  - Added count-backed paginated response:
    - `total`
    - `offset`
    - `limit`
    - `returned`
    - `has_more`
  - Kept query ordering stable and efficient for large delivery histories.

### Tests
- Added test_webhook_delivery_listing.py
  - Verifies filtered delivery listing returns the expected total count and only matching rows.
  - Verifies pagination metadata and offset-based paging behavior.

### Validation
- No diagnostics errors found in modified files.

Made changes.

Closes #233 