### PR TITLE
standardize wallet audit event taxonomy

### DIFF
--- a/app/api/v1/endpoints/audit.py
+++ b/app/api/v1/endpoints/audit.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
+from typing import Optional
 from app.services.audit_log import audit_log
 from app.core.security import require_admin
 
@@ -6,5 +7,20 @@ router = APIRouter(prefix="/audit", tags=["audit"])
 
 
 @router.get("")
-def get_audit_log(current_user=Depends(require_admin)):
-    return audit_log.list()
+def get_audit_log(
+    event_type_prefix: Optional[str] = Query(
+        None,
+        description=(
+            "Filter events by type prefix. "
+            "Use 'wallet.' to return all wallet-related events."
+        ),
+    ),
+    limit: int = Query(50, ge=1, le=500, description="Maximum number of records to return."),
+    offset: int = Query(0, ge=0, description="Number of records to skip for pagination."),
+    current_user=Depends(require_admin),
+):
+    return audit_log.list(
+        event_type_prefix=event_type_prefix,
+        limit=limit,
+        offset=offset,
+    )

--- a/app/api/v1/endpoints/jobs.py
+++ b/app/api/v1/endpoints/jobs.py
@@ -16,7 +16,7 @@ from app.services.audit_log import audit_log
 from app.services.metrics import increment_counter, timer
 from app.tasks.celery_app import celery_app
 from app.tasks.sla_tasks import enqueue_sla_computation, enqueue_bulk_sla_computation
-from app.tasks.webhook_tasks import dispatch_webhook_event
+from app.tasks.webhook_tasks import dispatch_webhook_delivery
 from app.utils.correlation import get_correlation_id
 from app.utils.logging import get_structured_logger
 from app.core.security import require_engineer, require_admin
@@ -453,8 +453,8 @@ def retry_job(
             )
         elif job.job_type == JobType.WEBHOOK_DISPATCH:
             # For webhook jobs, re-dispatch with the original payload
-            from app.tasks.webhook_tasks import dispatch_webhook_event
-            task_result = dispatch_webhook_event.delay(payload)
+            from app.tasks.webhook_tasks import dispatch_webhook_delivery
+            task_result = dispatch_webhook_delivery.delay(payload)
             job.celery_task_id = task_result.id
             db.commit()
             db.refresh(job)

--- a/app/api/v1/endpoints/wallets.py
+++ b/app/api/v1/endpoints/wallets.py
@@ -91,4 +91,18 @@ def get_wallet_balance(
     balance = WalletRegistry.get_balance(address, refresh=refresh)
     if not balance:
         raise HTTPException(status_code=404, detail="Wallet not found")
+    # Complete fetch failure -- no data at all, typed 503 so callers can distinguish
+    # this from a 404 and implement their own retry or circuit-break logic.
+    if balance.error_code == "FETCH_FAILED":
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={
+                "code": balance.error_code,
+                "detail": balance.error_detail,
+                "address": address,
+            },
+        )
+    # Stale-fallback: data is available but may be expired. Return 200 so the
+    # client still gets a usable payload; error_code/error_detail in the body
+    # signal the degraded state.
     return balance

--- a/app/api/v1/endpoints/wallets.py
+++ b/app/api/v1/endpoints/wallets.py
@@ -11,6 +11,7 @@ from app.models.wallet import (
     WalletTrustlineResponse,
 )
 from app.services.wallet_registry import WalletRegistry
+from app.services.audit_log import audit_log, WalletAuditEvents
 from app.core.security import require_engineer
 
 router = APIRouter()
@@ -18,14 +19,41 @@ router = APIRouter()
 
 @router.post("/create", response_model=WalletCreateResponse, status_code=status.HTTP_201_CREATED)
 def create_wallet(payload: WalletCreateRequest, current_user=Depends(require_engineer)):
-    return WalletRegistry.create_wallet(payload)
+    actor_id = getattr(current_user, "id", None)
+    try:
+        result = WalletRegistry.create_wallet(payload)
+        audit_log.log(
+            WalletAuditEvents.WALLET_CREATED,
+            actor_id=actor_id,
+            details={"user_id": payload.user_id if hasattr(payload, "user_id") else None},
+        )
+        return result
+    except Exception as exc:
+        audit_log.log(
+            WalletAuditEvents.WALLET_CREATE_FAILED,
+            actor_id=actor_id,
+            details={"error": str(exc)},
+        )
+        raise
 
 
 @router.post("/link", response_model=Wallet)
 def link_wallet(payload: WalletLinkRequest, current_user=Depends(require_engineer)):
+    actor_id = getattr(current_user, "id", None)
     try:
-        return WalletRegistry.link_wallet(payload)
+        result = WalletRegistry.link_wallet(payload)
+        audit_log.log(
+            WalletAuditEvents.WALLET_LINKED,
+            actor_id=actor_id,
+            details={"user_id": payload.user_id if hasattr(payload, "user_id") else None},
+        )
+        return result
     except ValueError as exc:
+        audit_log.log(
+            WalletAuditEvents.WALLET_LINK_FAILED,
+            actor_id=actor_id,
+            details={"error": str(exc)},
+        )
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc))
 
 
@@ -40,10 +68,26 @@ def get_wallet(
     refresh: bool = Query(False, description="Force a live re-fetch instead of returning cached data"),
     current_user=Depends(require_engineer),
 ):
-    wallet = WalletRegistry.get_wallet(user_id, refresh=refresh)
-    if not wallet:
-        raise HTTPException(status_code=404, detail="Wallet not found")
-    return wallet
+    actor_id = getattr(current_user, "id", None)
+    try:
+        wallet = WalletRegistry.get_wallet(user_id, refresh=refresh)
+        if not wallet:
+            raise HTTPException(status_code=404, detail="Wallet not found")
+        audit_log.log(
+            WalletAuditEvents.WALLET_FETCHED,
+            actor_id=actor_id,
+            details={"user_id": user_id, "refresh": refresh},
+        )
+        return wallet
+    except HTTPException:
+        raise
+    except Exception as exc:
+        audit_log.log(
+            WalletAuditEvents.WALLET_FETCH_FAILED,
+            actor_id=actor_id,
+            details={"user_id": user_id, "error": str(exc)},
+        )
+        raise
 
 
 @router.get("/{user_id}/status", response_model=WalletStatusResponse)
@@ -52,10 +96,26 @@ def get_wallet_status(
     refresh: bool = Query(False, description="Force a live re-fetch instead of returning cached data"),
     current_user=Depends(require_engineer),
 ):
-    wallet_status = WalletRegistry.get_status(user_id, refresh=refresh)
-    if not wallet_status:
-        raise HTTPException(status_code=404, detail="Wallet not found")
-    return wallet_status
+    actor_id = getattr(current_user, "id", None)
+    try:
+        wallet_status = WalletRegistry.get_status(user_id, refresh=refresh)
+        if not wallet_status:
+            raise HTTPException(status_code=404, detail="Wallet not found")
+        audit_log.log(
+            WalletAuditEvents.WALLET_STATUS_CHECKED,
+            actor_id=actor_id,
+            details={"user_id": user_id, "refresh": refresh},
+        )
+        return wallet_status
+    except HTTPException:
+        raise
+    except Exception as exc:
+        audit_log.log(
+            WalletAuditEvents.WALLET_STATUS_CHECK_FAILED,
+            actor_id=actor_id,
+            details={"user_id": user_id, "error": str(exc)},
+        )
+        raise
 
 
 @router.get("/{user_id}/trustline", response_model=WalletTrustlineResponse, summary="Check trustline readiness for a wallet")
@@ -64,10 +124,26 @@ def get_wallet_trustline(
     refresh: bool = Query(False, description="Force a live re-fetch instead of returning cached data"),
     current_user=Depends(require_engineer),
 ):
-    result = WalletRegistry.get_trustline(user_id, refresh=refresh)
-    if not result:
-        raise HTTPException(status_code=404, detail="Wallet not found")
-    return result
+    actor_id = getattr(current_user, "id", None)
+    try:
+        result = WalletRegistry.get_trustline(user_id, refresh=refresh)
+        if not result:
+            raise HTTPException(status_code=404, detail="Wallet not found")
+        audit_log.log(
+            WalletAuditEvents.WALLET_TRUSTLINE_CHECKED,
+            actor_id=actor_id,
+            details={"user_id": user_id, "refresh": refresh},
+        )
+        return result
+    except HTTPException:
+        raise
+    except Exception as exc:
+        audit_log.log(
+            WalletAuditEvents.WALLET_TRUSTLINE_CHECK_FAILED,
+            actor_id=actor_id,
+            details={"user_id": user_id, "error": str(exc)},
+        )
+        raise
 
 
 @router.get("/{user_id}/funding-state", response_model=WalletFundingStateResponse, summary="Get current funding state of a wallet")
@@ -76,10 +152,26 @@ def get_wallet_funding_state(
     refresh: bool = Query(False, description="Force a live re-fetch instead of returning cached data"),
     current_user=Depends(require_engineer),
 ):
-    result = WalletRegistry.get_funding_state(user_id, refresh=refresh)
-    if not result:
-        raise HTTPException(status_code=404, detail="Wallet not found")
-    return result
+    actor_id = getattr(current_user, "id", None)
+    try:
+        result = WalletRegistry.get_funding_state(user_id, refresh=refresh)
+        if not result:
+            raise HTTPException(status_code=404, detail="Wallet not found")
+        audit_log.log(
+            WalletAuditEvents.WALLET_FUNDING_STATE_CHECKED,
+            actor_id=actor_id,
+            details={"user_id": user_id, "refresh": refresh},
+        )
+        return result
+    except HTTPException:
+        raise
+    except Exception as exc:
+        audit_log.log(
+            WalletAuditEvents.WALLET_FUNDING_STATE_CHECK_FAILED,
+            actor_id=actor_id,
+            details={"user_id": user_id, "error": str(exc)},
+        )
+        raise
 
 
 @router.get("/{address}/balance", response_model=WalletBalanceResponse)
@@ -88,21 +180,23 @@ def get_wallet_balance(
     refresh: bool = Query(False, description="Force a live re-fetch instead of returning cached data"),
     current_user=Depends(require_engineer),
 ):
-    balance = WalletRegistry.get_balance(address, refresh=refresh)
-    if not balance:
-        raise HTTPException(status_code=404, detail="Wallet not found")
-    # Complete fetch failure -- no data at all, typed 503 so callers can distinguish
-    # this from a 404 and implement their own retry or circuit-break logic.
-    if balance.error_code == "FETCH_FAILED":
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail={
-                "code": balance.error_code,
-                "detail": balance.error_detail,
-                "address": address,
-            },
+    actor_id = getattr(current_user, "id", None)
+    try:
+        balance = WalletRegistry.get_balance(address, refresh=refresh)
+        if not balance:
+            raise HTTPException(status_code=404, detail="Wallet not found")
+        audit_log.log(
+            WalletAuditEvents.WALLET_BALANCE_CHECKED,
+            actor_id=actor_id,
+            details={"address": address, "refresh": refresh},
         )
-    # Stale-fallback: data is available but may be expired. Return 200 so the
-    # client still gets a usable payload; error_code/error_detail in the body
-    # signal the degraded state.
-    return balance
+        return balance
+    except HTTPException:
+        raise
+    except Exception as exc:
+        audit_log.log(
+            WalletAuditEvents.WALLET_BALANCE_CHECK_FAILED,
+            actor_id=actor_id,
+            details={"address": address, "error": str(exc)},
+        )
+        raise

--- a/app/api/v1/endpoints/webhooks.py
+++ b/app/api/v1/endpoints/webhooks.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, HttpUrl, field_validator
-from sqlalchemy import cast, func, or_, String
+from sqlalchemy import JSON, String, cast, func, or_
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import Session
 
 from app.models.auth import AuthUser
 from app.models.enums import Role
-from app.services.auth_store import AuthStore
 from app.db.session import get_db
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -56,6 +55,7 @@ def _extract_bearer_token(authorization: str | None) -> str:
 def get_current_user(
     authorization: str | None = Header(default=None), db: Session = Depends(get_db)
 ) -> AuthUser:
+    from app.services.auth_store import AuthStore
     token = _extract_bearer_token(authorization)
     user = AuthStore.get_user_for_token(token, db=db)
     if not user:

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from sqlalchemy import Column, String, DateTime, Text, Enum as SAEnum, Float, JSON
+from sqlalchemy import Column, DateTime, Enum, Enum as SAEnum, Float, Integer, JSON, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 import enum
 

--- a/app/models/orm/audit_log.py
+++ b/app/models/orm/audit_log.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, String, Integer, JSON
 from app.db.base import Base
 

--- a/app/models/orm/outage.py
+++ b/app/models/orm/outage.py
@@ -1,6 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, Float, Integer, String, Text
+from sqlalchemy import ARRAY, Column, DateTime, Float, Integer, JSON, String, Text
 from sqlalchemy.dialects.postgresql import ARRAY, JSON
 
 from app.db.base import Base

--- a/app/models/orm/payment.py
+++ b/app/models/orm/payment.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String
 

--- a/app/models/orm/session.py
+++ b/app/models/orm/session.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, String, Integer, ForeignKey
 from app.db.base import Base
 

--- a/app/models/orm/sla.py
+++ b/app/models/orm/sla.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.orm import relationship

--- a/app/models/orm/sla_snapshot.py
+++ b/app/models/orm/sla_snapshot.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import hashlib
 import json
 

--- a/app/models/orm/token_family.py
+++ b/app/models/orm/token_family.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, String, Integer, Boolean, ForeignKey
 from app.db.base import Base
 

--- a/app/models/orm/user.py
+++ b/app/models/orm/user.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy import Column, DateTime, Integer, String
 from app.db.base import Base
 

--- a/app/models/outage.py
+++ b/app/models/outage.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 
 class Location(BaseModel):

--- a/app/models/outage_dto.py
+++ b/app/models/outage_dto.py
@@ -54,6 +54,7 @@ class OutageCreate(BaseModel):
     affected_subscribers: Optional[int] = Field(default=None, ge=0)
     assigned_to: Optional[str] = None
     created_by: Optional[str] = None
+    resolved_at: Optional[datetime] = None
     location: Optional[Location] = None
 
     @field_validator("site_name")

--- a/app/models/wallet.py
+++ b/app/models/wallet.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, Literal, Optional
 import re
 
 from pydantic import BaseModel, Field, field_validator
@@ -60,6 +60,10 @@ class WalletBalanceResponse(BaseModel):
     cache_status: str = "fresh"
     cache_ttl_seconds: int | None = None
     cached_at: datetime | None = None
+    # #283: source distinguishes cache hit from live read or stale fallback
+    source: Literal["cache", "live", "stale_fallback"] = "live"
+    error_code: str | None = None
+    error_detail: str | None = None
 
 
 class WalletStatusResponse(BaseModel):

--- a/app/models/webhook.py
+++ b/app/models/webhook.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from sqlalchemy import Column, String, Boolean, DateTime, Text, Integer, ForeignKey, Enum as SAEnum
+from sqlalchemy import Boolean, Column, DateTime, Enum, Enum as SAEnum, ForeignKey, Integer, JSON, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 import enum

--- a/app/services/audit_log.py
+++ b/app/services/audit_log.py
@@ -5,9 +5,69 @@ from app.models.orm.audit_log import AuditLogORM
 from app.db.session import SessionLocal
 from app.utils.correlation import get_correlation_id
 
+
+class WalletAuditEvents:
+    """Standardized audit event taxonomy for all wallet-related operations."""
+
+    # Creation
+    WALLET_CREATED = "wallet.created"
+    WALLET_CREATE_FAILED = "wallet.create_failed"
+
+    # Linking
+    WALLET_LINKED = "wallet.linked"
+    WALLET_LINK_FAILED = "wallet.link_failed"
+
+    # Fetch
+    WALLET_FETCHED = "wallet.fetched"
+    WALLET_FETCH_FAILED = "wallet.fetch_failed"
+
+    # Status
+    WALLET_STATUS_CHECKED = "wallet.status_checked"
+    WALLET_STATUS_CHECK_FAILED = "wallet.status_check_failed"
+
+    # Trustline
+    WALLET_TRUSTLINE_CHECKED = "wallet.trustline_checked"
+    WALLET_TRUSTLINE_CHECK_FAILED = "wallet.trustline_check_failed"
+
+    # Funding state
+    WALLET_FUNDING_STATE_CHECKED = "wallet.funding_state_checked"
+    WALLET_FUNDING_STATE_CHECK_FAILED = "wallet.funding_state_check_failed"
+
+    # Balance
+    WALLET_BALANCE_CHECKED = "wallet.balance_checked"
+    WALLET_BALANCE_CHECK_FAILED = "wallet.balance_check_failed"
+
+    # Prefix used by the audit query endpoint to filter all wallet events
+    PREFIX = "wallet."
+
+
 class AuditLogService:
+    _SENSITIVE_KEYS = {
+        "password",
+        "token",
+        "access_token",
+        "refresh_token",
+        "secret",
+        "secret_key",
+        # Wallet-specific secrets
+        "seed",
+        "secret_seed",
+        "private_key",
+        "mnemonic",
+    }
+
     def __init__(self, db_session_factory=None):
         self.db_session_factory = db_session_factory or SessionLocal
+
+    def _sanitize(self, details: Optional[dict[str, Any]]) -> dict[str, Any]:
+        """Return a copy of details with all sensitive fields redacted."""
+        if not details:
+            return {}
+        safe = details.copy()
+        for key in self._SENSITIVE_KEYS:
+            if key in safe:
+                safe[key] = "[REDACTED]"
+        return safe
 
     def log_event(
         self,
@@ -16,32 +76,24 @@ class AuditLogService:
         email: Optional[str] = None,
         actor_id: Optional[str] = None,
         details: Optional[dict[str, Any]] = None,
-        correlation_id: Optional[str] = None
+        correlation_id: Optional[str] = None,
     ) -> None:
         """
         Records a structured audit event with actor attribution and correlation context.
-        
+
         BE-010 Enhancements:
         - actor_id: Consistent user identifier for cross-event correlation
         - correlation_id: Request correlation ID to link related events
         - Sensitive data sanitization to prevent secret leakage
-        
+
         Args:
             db: Database session
-            event_type: Type of event (e.g., 'login_success', 'job_retry_initiated')
+            event_type: Namespaced event type (e.g., 'wallet.created', 'login_success')
             email: User email (legacy field, kept for backward compatibility)
             actor_id: User ID for consistent actor tracking (preferred over email)
-            details: Event details dict (will be sanitized)
-            correlation_id: Request correlation ID from context (auto-detected if not provided)
+            details: Event details dict (will be sanitized before persistence)
+            correlation_id: Request correlation ID (auto-detected from context if omitted)
         """
-        # Sanitization: prevent leaking common sensitive keys
-        safe_details = details.copy() if details else {}
-        sensitive_keys = {"password", "token", "access_token", "refresh_token", "secret", "secret_key"}
-        for key in sensitive_keys:
-            if key in safe_details:
-                safe_details[key] = "[REDACTED]"
-        
-        # Auto-detect correlation_id from request context if not provided
         if correlation_id is None:
             correlation_id = get_correlation_id()
 
@@ -50,19 +102,67 @@ class AuditLogService:
             email=email,
             actor_id=actor_id,
             correlation_id=correlation_id,
-            details=safe_details,
-            created_at=datetime.now(timezone.utc)
+            details=self._sanitize(details),
+            created_at=datetime.now(timezone.utc),
         )
         db.add(audit_entry)
         db.commit()
 
-    def log(self, event_type: str, details: Optional[dict[str, Any]] = None) -> None:
+    def log(
+        self,
+        event_type: str,
+        details: Optional[dict[str, Any]] = None,
+        actor_id: Optional[str] = None,
+        email: Optional[str] = None,
+    ) -> None:
         """
-        Simplified log method for compatibility with existing code.
-        Uses its own session if not provided.
+        Simplified log method for fire-and-forget use cases.
+        Opens and closes its own session internally.
         """
         with self.db_session_factory() as db:
-            self.log_event(db, event_type, details=details)
+            self.log_event(db, event_type, email=email, actor_id=actor_id, details=details)
 
-# Create a singleton instance for common use
+    def list(
+        self,
+        event_type_prefix: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """
+        Return audit log entries ordered by most recent first.
+
+        Args:
+            event_type_prefix: If provided, only return events whose event_type
+                               starts with this string (e.g., 'wallet.' returns all
+                               wallet events). Case-sensitive.
+            limit: Maximum number of records to return.
+            offset: Number of records to skip (for pagination).
+        """
+        with self.db_session_factory() as db:
+            query = db.query(AuditLogORM)
+            if event_type_prefix:
+                query = query.filter(
+                    AuditLogORM.event_type.like(f"{event_type_prefix}%")
+                )
+            rows = (
+                query.order_by(AuditLogORM.created_at.desc())
+                .offset(offset)
+                .limit(limit)
+                .all()
+            )
+            return [
+                {
+                    "id": r.id,
+                    "event_type": r.event_type,
+                    "email": r.email,
+                    "actor_id": r.actor_id,
+                    "correlation_id": r.correlation_id,
+                    "details": r.details,
+                    "created_at": r.created_at.isoformat() if r.created_at else None,
+                }
+                for r in rows
+            ]
+
+
+# Singleton instance for common use
 audit_log = AuditLogService()

--- a/app/services/contracts/sla_adapter.py
+++ b/app/services/contracts/sla_adapter.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
+from datetime import datetime, UTC
+from typing import Any, Callable, Literal, Optional
 
 from app.core.config import settings
 from app.services.sla import SLACalculator
+from app.utils.cache import CacheResult, TTLCache
 
 
 class SLAContractAdapter:
@@ -50,3 +53,124 @@ class SLAContractAdapter:
             "rating": rating_code_map[local_result.rating],
             "contract_metadata": cls.get_runtime_metadata(),
         }
+
+
+# ---------------------------------------------------------------------------
+# Balance fetch adapter (#283)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BalanceFetchError:
+    """Typed error returned when a balance read degrades."""
+
+    code: Literal["STALE_FALLBACK", "FETCH_FAILED"]
+    detail: str
+
+
+@dataclass
+class BalanceFetchResult:
+    """Result of a balance fetch including freshness metadata and any error.
+
+    source values:
+        "live"           -- freshly fetched from chain (or simulator)
+        "cache"          -- valid cache hit within TTL
+        "stale_fallback" -- TTL expired but live fetch failed; stale data served
+    """
+
+    address: str
+    balances: dict
+    source: Literal["live", "cache", "stale_fallback"]
+    cached_at: Optional[datetime]
+    ttl_remaining: Optional[int]   # seconds; None when freshly fetched with no prior TTL
+    is_degraded: bool = False
+    error: Optional[BalanceFetchError] = None
+
+
+class BalanceFetchAdapter:
+    """Wallet balance cache with freshness guarantees and fallback (#283).
+
+    Fetch order:
+        1. Return a valid cache entry if within TTL (source="cache").
+        2. Call live_fetcher when the cache is missing, stale, or
+           force_refresh=True (source="live").
+        3. On live_fetcher failure, serve the expired cache entry as a
+           stale fallback (source="stale_fallback", is_degraded=True).
+        4. When no cached entry exists and live_fetcher fails, return a
+           typed error result with empty balances (is_degraded=True).
+
+    Cache invalidation:
+        Explicit  -- call invalidate(address) after mutations that change
+                     balance state (e.g. funding a wallet).
+        TTL-based -- controlled by the ttl_seconds passed at construction
+                     (default: WALLET_CACHE_TTL_SECONDS from settings).
+    """
+
+    def __init__(self, cache: Optional[TTLCache] = None) -> None:
+        self._cache: TTLCache = (
+            cache if cache is not None
+            else TTLCache(ttl_seconds=settings.WALLET_CACHE_TTL_SECONDS)
+        )
+
+    def fetch(
+        self,
+        address: str,
+        live_fetcher: Callable[[str], dict],
+        force_refresh: bool = False,
+    ) -> BalanceFetchResult:
+        meta: Optional[CacheResult] = self._cache.get_with_meta(address)
+
+        if not force_refresh and meta is not None and not meta.is_expired:
+            return BalanceFetchResult(
+                address=address,
+                balances=meta.value["balances"],
+                source="cache",
+                cached_at=meta.value["cached_at"],
+                ttl_remaining=int(meta.ttl_remaining),
+            )
+
+        now = datetime.now(UTC)
+        try:
+            balances = live_fetcher(address)
+            self._cache.set(address, {"balances": balances, "cached_at": now})
+            return BalanceFetchResult(
+                address=address,
+                balances=balances,
+                source="live",
+                cached_at=now,
+                ttl_remaining=self._cache._ttl,
+            )
+        except Exception as exc:
+            if meta is not None:
+                return BalanceFetchResult(
+                    address=address,
+                    balances=meta.value["balances"],
+                    source="stale_fallback",
+                    cached_at=meta.value["cached_at"],
+                    ttl_remaining=0,
+                    is_degraded=True,
+                    error=BalanceFetchError(
+                        code="STALE_FALLBACK",
+                        detail=f"Live fetch failed; serving stale data. Reason: {exc}",
+                    ),
+                )
+            return BalanceFetchResult(
+                address=address,
+                balances={},
+                source="live",
+                cached_at=None,
+                ttl_remaining=None,
+                is_degraded=True,
+                error=BalanceFetchError(
+                    code="FETCH_FAILED",
+                    detail=f"Balance fetch failed and no cached data is available. Reason: {exc}",
+                ),
+            )
+
+    def invalidate(self, address: str) -> None:
+        """Explicitly evict the cached entry for address after a balance-changing write."""
+        self._cache.invalidate(address)
+
+
+# Module-level singleton -- shared across all requests in this process.
+balance_fetch_adapter = BalanceFetchAdapter()

--- a/app/services/wallet_registry.py
+++ b/app/services/wallet_registry.py
@@ -4,6 +4,7 @@ from datetime import datetime, UTC, timedelta
 from uuid import uuid4
 
 from app.core.config import settings
+from app.services.contracts.sla_adapter import BalanceFetchResult, balance_fetch_adapter
 from app.models.wallet import (
     AssetBalance,
     Wallet,
@@ -52,6 +53,28 @@ class WalletRegistry:
         cls._wallets_by_user[wallet.user_id] = refreshed
         cls._wallets_by_address[wallet.public_key] = refreshed
         return refreshed
+
+    @classmethod
+    def _build_live_balances(cls, address: str) -> dict:
+        """Compute live balances for address. Raises ValueError if not in registry.
+
+        In production this would call the Stellar Horizon API and propagate
+        any network or chain errors to the caller, triggering stale fallback.
+        """
+        wallet = cls._wallets_by_address.get(address)
+        if not wallet:
+            raise ValueError(f"Address {address} not found in registry")
+        wallet = cls._refresh_wallet(wallet)
+        xlm_balance = "1.0000000" if wallet.funded else "0.0000000"
+        balances: dict = {"XLM": AssetBalance(balance=xlm_balance, asset_type="native")}
+        if wallet.trustline_ready:
+            balances["USDC"] = AssetBalance(
+                balance="0.0000000",
+                asset_type="credit_alphanum4",
+                asset_code="USDC",
+                asset_issuer="TEST_ISSUER",
+            )
+        return balances
 
     @classmethod
     def _build_public_key(cls) -> str:
@@ -173,31 +196,32 @@ class WalletRegistry:
 
     @classmethod
     def get_balance(cls, address: str, refresh: bool = False) -> WalletBalanceResponse | None:
-        wallet = cls._wallets_by_address.get(address)
-        if not wallet:
-            return None
-        if refresh or cls._is_stale(wallet):
-            wallet = cls._refresh_wallet(wallet)
+        if not cls._wallets_by_address.get(address):
+            return None  # 404 -- address not in registry
 
-        xlm_balance = "1.0000000" if wallet.funded else "0.0000000"
-        balances = {
-            "XLM": AssetBalance(balance=xlm_balance, asset_type="native"),
-        }
-        if wallet.trustline_ready:
-            balances["USDC"] = AssetBalance(
-                balance="0.0000000",
-                asset_type="credit_alphanum4",
-                asset_code="USDC",
-                asset_issuer="TEST_ISSUER",
-            )
-        cache_ttl = cls._get_cache_ttl_remaining(wallet)
+        result: BalanceFetchResult = balance_fetch_adapter.fetch(
+            address=address,
+            live_fetcher=lambda addr: cls._build_live_balances(addr),
+            force_refresh=refresh,
+        )
+
+        # Map adapter source to legacy cache_status for backwards compatibility
+        legacy_cache_status = {
+            "live": "live",
+            "cache": "fresh",
+            "stale_fallback": "stale",
+        }.get(result.source, "fresh")
+
         return WalletBalanceResponse(
             address=address,
-            balances=balances,
-            last_updated=wallet.last_updated,
-            cache_status=wallet.cache_status,
-            cache_ttl_seconds=cache_ttl,
-            cached_at=wallet.cached_at,
+            balances=result.balances,
+            last_updated=result.cached_at or cls._now(),
+            cache_status=legacy_cache_status,
+            cache_ttl_seconds=result.ttl_remaining,
+            cached_at=result.cached_at,
+            source=result.source,
+            error_code=result.error.code if result.error else None,
+            error_detail=result.error.detail if result.error else None,
         )
 
     @classmethod

--- a/app/utils/cache.py
+++ b/app/utils/cache.py
@@ -9,8 +9,38 @@ Usage:
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass
 from threading import Lock
 from typing import Any, Optional
+
+
+# Explicit invalidation policy for this module.
+# 1. TTL-based expiry: every entry expires after `ttl_seconds`.
+# 2. Write-through invalidation: callers must call `invalidate` or
+#    `invalidate_prefix` after any mutation that changes cached state.
+# 3. Stale-data access: `get_with_meta` returns expired entries instead
+#    of evicting them, enabling stale-fallback reads when live fetch fails.
+CACHE_INVALIDATION_POLICY: str = (
+    "TTL-based expiry (configurable) with explicit write-through invalidation. "
+    "Expired entries are retained for stale-fallback reads via get_with_meta."
+)
+
+
+@dataclass
+class CacheResult:
+    """Metadata-rich cache lookup result returned by `get_with_meta`.
+
+    Unlike `get`, stale entries are NOT evicted -- the caller decides
+    whether to serve the value or re-fetch from the source.
+    """
+
+    value: Any
+    age_seconds: float      # wall-clock age since the entry was stored
+    ttl_remaining: float    # 0.0 when expired
+
+    @property
+    def is_expired(self) -> bool:
+        return self.ttl_remaining <= 0.0
 
 
 class TTLCache:
@@ -37,6 +67,24 @@ class TTLCache:
                 del self._store[key]
                 return None
             return value
+
+    def get_with_meta(self, key: str) -> 'CacheResult | None':
+        """Return the cache entry and its metadata even when the TTL has expired.
+
+        Unlike `get`, this method does NOT evict the expired entry.  Use it
+        when you need stale data as a fallback after a failed live fetch.
+        Returns None only when the key was never set or was explicitly
+        invalidated.
+        """
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+            value, expires_at = entry
+            now = time.monotonic()
+            age = now - (expires_at - self._ttl)
+            ttl_remaining = max(0.0, expires_at - now)
+            return CacheResult(value=value, age_seconds=age, ttl_remaining=ttl_remaining)
 
     def set(self, key: str, value: Any) -> None:
         with self._lock:

--- a/tests/test_wallet_balance_cache.py
+++ b/tests/test_wallet_balance_cache.py
@@ -1,0 +1,295 @@
+"""Tests for wallet balance caching with freshness guarantees and fallback (#283).
+
+Covers:
+- TTLCache.get_with_meta: miss / fresh hit / stale hit without eviction
+- BalanceFetchAdapter: cache hit, miss, force-refresh, stale-fallback, FETCH_FAILED
+- GET /api/v1/wallets/{address}/balance: freshness metadata, 503 on FETCH_FAILED,
+  200 with error fields on stale fallback
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, UTC
+from unittest.mock import patch
+
+import pytest
+
+from app.main import app
+from app.core.security import require_engineer
+from app.models.wallet import AssetBalance, WalletLinkRequest
+from app.services.contracts.sla_adapter import (
+    BalanceFetchAdapter,
+    balance_fetch_adapter,
+)
+from app.services.wallet_registry import WalletRegistry
+from app.utils.cache import CacheResult, TTLCache
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Valid Stellar public key format: G + 55 chars from [A-Z2-7]
+FAKE_ADDRESS = "G" + "A" * 55
+
+
+def _register_wallet(
+    address: str = FAKE_ADDRESS,
+    user_id: str = "test-user-283",
+    funded: bool = True,
+    trustline: bool = False,
+) -> None:
+    WalletRegistry.link_wallet(
+        WalletLinkRequest(
+            user_id=user_id,
+            public_key=address,
+            funded=funded,
+            trustline_ready=trustline,
+        )
+    )
+
+
+def _fresh_asset_balances() -> dict:
+    return {"XLM": AssetBalance(balance="1.0000000", asset_type="native")}
+
+
+def _make_adapter(ttl: int = 60) -> BalanceFetchAdapter:
+    return BalanceFetchAdapter(cache=TTLCache(ttl_seconds=ttl))
+
+
+def _force_expire(cache: TTLCache, key: str) -> None:
+    """Backdates the expiry timestamp so the entry is immediately stale."""
+    with cache._lock:
+        val, _ = cache._store[key]
+        cache._store[key] = (val, time.monotonic() - 1)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _mock_engineer():
+    return None
+
+
+@pytest.fixture(autouse=True)
+def override_auth():
+    app.dependency_overrides[require_engineer] = _mock_engineer
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    """Reset registry and shared adapter cache before and after every test."""
+    WalletRegistry._wallets_by_user.clear()
+    WalletRegistry._wallets_by_address.clear()
+    WalletRegistry._link_locks.clear()
+    balance_fetch_adapter._cache._store.clear()
+    yield
+    WalletRegistry._wallets_by_user.clear()
+    WalletRegistry._wallets_by_address.clear()
+    WalletRegistry._link_locks.clear()
+    balance_fetch_adapter._cache._store.clear()
+
+
+# ---------------------------------------------------------------------------
+# TTLCache.get_with_meta
+# ---------------------------------------------------------------------------
+
+
+class TestGetWithMeta:
+    def test_returns_none_for_absent_key(self):
+        cache = TTLCache(ttl_seconds=60)
+        assert cache.get_with_meta("missing") is None
+
+    def test_returns_result_for_fresh_entry(self):
+        cache = TTLCache(ttl_seconds=60)
+        cache.set("k", {"v": 1})
+        result = cache.get_with_meta("k")
+        assert isinstance(result, CacheResult)
+        assert result.value == {"v": 1}
+        assert not result.is_expired
+        assert result.ttl_remaining > 0
+        assert result.age_seconds >= 0
+
+    def test_returns_stale_entry_without_evicting(self):
+        cache = TTLCache(ttl_seconds=60)
+        cache.set("k", {"v": 1})
+        _force_expire(cache, "k")
+        result = cache.get_with_meta("k")
+        assert result is not None
+        assert result.is_expired
+        assert result.ttl_remaining == 0.0
+        # Entry must survive in the store so fallback reads can use it
+        assert "k" in cache._store
+
+    def test_regular_get_still_evicts_expired_entries(self):
+        cache = TTLCache(ttl_seconds=60)
+        cache.set("k", {"v": 1})
+        _force_expire(cache, "k")
+        assert cache.get("k") is None
+        assert "k" not in cache._store
+
+    def test_returns_none_after_explicit_invalidate(self):
+        cache = TTLCache(ttl_seconds=60)
+        cache.set("k", {"v": 1})
+        cache.invalidate("k")
+        assert cache.get_with_meta("k") is None
+
+
+# ---------------------------------------------------------------------------
+# BalanceFetchAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestBalanceFetchAdapter:
+    def test_cache_miss_calls_live_fetcher(self):
+        adapter = _make_adapter()
+        calls: list[str] = []
+
+        def live(addr: str) -> dict:
+            calls.append(addr)
+            return _fresh_asset_balances()
+
+        result = adapter.fetch(FAKE_ADDRESS, live)
+        assert result.source == "live"
+        assert not result.is_degraded
+        assert result.error is None
+        assert len(calls) == 1
+
+    def test_cache_hit_skips_live_fetcher(self):
+        adapter = _make_adapter()
+        calls: list[str] = []
+
+        def live(addr: str) -> dict:
+            calls.append(addr)
+            return _fresh_asset_balances()
+
+        adapter.fetch(FAKE_ADDRESS, live)       # populates cache
+        result = adapter.fetch(FAKE_ADDRESS, live)  # should hit cache
+        assert result.source == "cache"
+        assert not result.is_degraded
+        assert len(calls) == 1                  # live called only once
+
+    def test_force_refresh_bypasses_valid_cache(self):
+        adapter = _make_adapter()
+        calls: list[str] = []
+
+        def live(addr: str) -> dict:
+            calls.append(addr)
+            return _fresh_asset_balances()
+
+        adapter.fetch(FAKE_ADDRESS, live)
+        result = adapter.fetch(FAKE_ADDRESS, live, force_refresh=True)
+        assert result.source == "live"
+        assert len(calls) == 2
+
+    def test_stale_fallback_when_live_fails(self):
+        adapter = _make_adapter(ttl=60)
+        sentinel = datetime.now(UTC)
+        adapter._cache.set(
+            FAKE_ADDRESS,
+            {"balances": _fresh_asset_balances(), "cached_at": sentinel},
+        )
+        _force_expire(adapter._cache, FAKE_ADDRESS)
+
+        def failing_live(addr: str) -> dict:
+            raise ConnectionError("Horizon unavailable")
+
+        result = adapter.fetch(FAKE_ADDRESS, failing_live)
+        assert result.source == "stale_fallback"
+        assert result.is_degraded
+        assert result.error is not None
+        assert result.error.code == "STALE_FALLBACK"
+        assert result.ttl_remaining == 0
+        assert result.cached_at == sentinel
+
+    def test_fetch_failed_when_no_cache_and_live_fails(self):
+        adapter = _make_adapter()
+
+        def failing_live(addr: str) -> dict:
+            raise RuntimeError("chain unreachable")
+
+        result = adapter.fetch(FAKE_ADDRESS, failing_live)
+        assert result.is_degraded
+        assert result.error is not None
+        assert result.error.code == "FETCH_FAILED"
+        assert result.balances == {}
+        assert result.cached_at is None
+
+    def test_invalidate_removes_entry(self):
+        adapter = _make_adapter()
+        adapter._cache.set(FAKE_ADDRESS, {"balances": {}, "cached_at": datetime.now(UTC)})
+        adapter.invalidate(FAKE_ADDRESS)
+        assert adapter._cache.get_with_meta(FAKE_ADDRESS) is None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/wallets/{address}/balance endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestWalletBalanceEndpoint:
+    def test_404_for_unknown_address(self, client):
+        resp = client.get(f"/api/v1/wallets/{FAKE_ADDRESS}/balance")
+        assert resp.status_code == 404
+
+    def test_freshness_metadata_present_on_live_fetch(self, client):
+        _register_wallet()
+        resp = client.get(f"/api/v1/wallets/{FAKE_ADDRESS}/balance")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"] in ("live", "cache")
+        assert data["cache_status"] in ("live", "fresh")
+        assert data["cached_at"] is not None
+        assert data["error_code"] is None
+        assert data["error_detail"] is None
+
+    def test_force_refresh_returns_live_source(self, client):
+        _register_wallet()
+        resp = client.get(f"/api/v1/wallets/{FAKE_ADDRESS}/balance?refresh=true")
+        assert resp.status_code == 200
+        assert resp.json()["source"] == "live"
+
+    def test_stale_fallback_returns_200_with_error_fields(self, client):
+        _register_wallet()
+        # Inject stale data directly into the shared adapter cache
+        sentinel = datetime.now(UTC)
+        balance_fetch_adapter._cache.set(
+            FAKE_ADDRESS,
+            {"balances": _fresh_asset_balances(), "cached_at": sentinel},
+        )
+        _force_expire(balance_fetch_adapter._cache, FAKE_ADDRESS)
+
+        with patch.object(
+            WalletRegistry,
+            "_build_live_balances",
+            side_effect=ConnectionError("Horizon down"),
+        ):
+            resp = client.get(f"/api/v1/wallets/{FAKE_ADDRESS}/balance")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"] == "stale_fallback"
+        assert data["error_code"] == "STALE_FALLBACK"
+        assert data["error_detail"] is not None
+        assert data["cache_status"] == "stale"
+
+    def test_503_on_fetch_failed_with_no_cache(self, client):
+        _register_wallet()
+        # Ensure adapter cache is empty for this address
+        balance_fetch_adapter._cache.invalidate(FAKE_ADDRESS)
+
+        with patch.object(
+            WalletRegistry,
+            "_build_live_balances",
+            side_effect=RuntimeError("chain down"),
+        ):
+            resp = client.get(f"/api/v1/wallets/{FAKE_ADDRESS}/balance")
+
+        assert resp.status_code == 503
+        detail = resp.json()["detail"]
+        assert detail["code"] == "FETCH_FAILED"
+        assert detail["address"] == FAKE_ADDRESS
+        assert detail["detail"] is not None


### PR DESCRIPTION
- Add WalletAuditEvents constants class with 14 namespaced event types
- Expand sensitive key redaction to cover seed, secret_seed, private_key, mnemonic
- Extract _sanitize() as reusable method on AuditLogService
- Add list() method with event_type_prefix, limit, offset for audit queries
- Fix broken GET /audit endpoint (audit_log.list() now exists)
- Add event_type_prefix, limit, offset query params to GET /audit
- Wire audit events into all 7 wallet endpoints (success + failure paths)

closes #290 

