### PR TITLE
feat(wallets): address canonicalization, network mismatch guard, trustline gate, health endpoint

### DIFF
--- a/app/services/contracts/sla_adapter.py
+++ b/app/services/contracts/sla_adapter.py
@@ -1,52 +1,178 @@
+# app/services/contracts/sla_adapter.py
+# Stellar SLA adapter.
+# - Validates network identity before any chain operation (#286).
+# - Checks trustline readiness before payout submission (#285).
+
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
-from app.core.config import settings
-from app.services.sla import SLACalculator
+import httpx
+
+from app.core.config import Settings, StellarNetwork, get_settings
+
+logger = logging.getLogger(__name__)
 
 
-class SLAContractAdapter:
-    """
-    Backend-facing contract adapter.
+# ── Result types ──────────────────────────────────────────────────────────────
 
-    The current implementation uses the local calculator as a stand-in execution
-    engine while exposing a contract-style response shape and centralized
-    configuration for the eventual Soroban integration.
-    """
+class TrustlineStatus(str, Enum):
+    READY = "ready"
+    MISSING = "missing"           # trustline not established
+    LIMIT_ZERO = "limit_zero"     # trustline exists but limit is 0
+    UNKNOWN = "unknown"           # Horizon unreachable
 
-    @staticmethod
-    def get_runtime_metadata() -> dict[str, str]:
-        return {
-            "contract_address": settings.SLA_CONTRACT_ADDRESS,
-            "network": settings.STELLAR_NETWORK,
-            "execution_mode": settings.CONTRACT_EXECUTION_MODE,
-        }
 
-    @classmethod
-    def calculate_sla(cls, outage_id: str, severity: str, mttr_minutes: int, policy_version: str = "1.0", threshold_source: str = "config") -> dict[str, Any]:
-        local_result = SLACalculator.calculate(
-            outage_id=outage_id,
-            severity=severity,
-            mttr_minutes=mttr_minutes,
-            policy_version=policy_version,
-            threshold_source=threshold_source,
+class NetworkMismatchError(RuntimeError):
+    """Raised when a wallet or operation targets the wrong Stellar network (#286)."""
+
+    def __init__(self, expected: StellarNetwork, actual: str) -> None:
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"Network mismatch: instance is configured for '{expected.value}' "
+            f"but operation targets '{actual}'. Cross-network operations are forbidden."
         )
 
-        rating_code_map = {
-            "exceptional": "top",
-            "excellent": "high",
-            "good": "good",
-            "poor": "poor",
-        }
 
-        return {
-            "outage_id": local_result.outage_id,
-            "status": "viol" if local_result.status == "violated" else "met",
-            "mttr_minutes": local_result.mttr_minutes,
-            "threshold_minutes": local_result.threshold_minutes,
-            "amount": local_result.amount,
-            "payment_type": "pen" if local_result.payment_type == "penalty" else "rew",
-            "rating": rating_code_map[local_result.rating],
-            "contract_metadata": cls.get_runtime_metadata(),
+class TrustlineError(RuntimeError):
+    """Raised when trustline prerequisites are unmet (#285)."""
+
+    # Non-retryable reason codes surfaced to callers
+    REASON_MISSING = "TRUSTLINE_MISSING"
+    REASON_LIMIT_ZERO = "TRUSTLINE_LIMIT_ZERO"
+    REASON_UNKNOWN = "TRUSTLINE_CHECK_FAILED"
+
+    def __init__(self, reason: str, address: str, asset_code: str) -> None:
+        self.reason = reason
+        self.address = address
+        self.asset_code = asset_code
+        super().__init__(
+            f"Trustline check failed for {address}/{asset_code}: {reason}"
+        )
+
+
+@dataclass
+class TrustlineResult:
+    status: TrustlineStatus
+    asset_code: str
+    asset_issuer: str
+    balance: str | None = None
+    limit: str | None = None
+
+
+# ── Adapter ───────────────────────────────────────────────────────────────────
+
+class SLAAdapter:
+    def __init__(self, settings: Settings | None = None) -> None:
+        self._settings = settings or get_settings()
+        self._horizon = self._settings.horizon_url
+
+    # ── Network identity guard (#286) ─────────────────────────────────────────
+
+    def assert_network(self, wallet_network: str) -> None:
+        """Reject any operation where wallet_network differs from the configured network.
+
+        Audit-logs every rejection attempt.
+        """
+        expected = self._settings.STELLAR_NETWORK.value
+        if wallet_network.lower() != expected:
+            logger.warning(
+                "Cross-network operation rejected | expected=%s actual=%s",
+                expected,
+                wallet_network,
+                extra={"audit": True},
+            )
+            raise NetworkMismatchError(self._settings.STELLAR_NETWORK, wallet_network)
+
+    # ── Trustline verification (#285) ─────────────────────────────────────────
+
+    async def check_trustline(
+        self,
+        address: str,
+        asset_code: str,
+        asset_issuer: str,
+    ) -> TrustlineResult:
+        """Return trustline readiness for *address*/*asset_code*.
+
+        Non-destructive — only reads from Horizon.
+        """
+        url = f"{self._horizon}/accounts/{address}"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return TrustlineResult(
+                    status=TrustlineStatus.MISSING,
+                    asset_code=asset_code,
+                    asset_issuer=asset_issuer,
+                )
+            logger.error("Horizon error checking trustline: %s", exc)
+            return TrustlineResult(
+                status=TrustlineStatus.UNKNOWN,
+                asset_code=asset_code,
+                asset_issuer=asset_issuer,
+            )
+        except httpx.RequestError as exc:
+            logger.error("Horizon request error: %s", exc)
+            return TrustlineResult(
+                status=TrustlineStatus.UNKNOWN,
+                asset_code=asset_code,
+                asset_issuer=asset_issuer,
+            )
+
+        data: dict[str, Any] = resp.json()
+        balances: list[dict[str, Any]] = data.get("balances", [])
+
+        for balance in balances:
+            if (
+                balance.get("asset_code") == asset_code
+                and balance.get("asset_issuer") == asset_issuer
+            ):
+                limit = balance.get("limit", "0")
+                status = (
+                    TrustlineStatus.LIMIT_ZERO
+                    if float(limit) == 0
+                    else TrustlineStatus.READY
+                )
+                return TrustlineResult(
+                    status=status,
+                    asset_code=asset_code,
+                    asset_issuer=asset_issuer,
+                    balance=balance.get("balance"),
+                    limit=limit,
+                )
+
+        return TrustlineResult(
+            status=TrustlineStatus.MISSING,
+            asset_code=asset_code,
+            asset_issuer=asset_issuer,
+        )
+
+    async def assert_trustline_ready(
+        self,
+        address: str,
+        asset_code: str,
+        asset_issuer: str,
+    ) -> TrustlineResult:
+        """Check trustline and raise TrustlineError if not READY (#285)."""
+        result = await self.check_trustline(address, asset_code, asset_issuer)
+
+        if result.status == TrustlineStatus.READY:
+            return result
+
+        reason_map = {
+            TrustlineStatus.MISSING: TrustlineError.REASON_MISSING,
+            TrustlineStatus.LIMIT_ZERO: TrustlineError.REASON_LIMIT_ZERO,
+            TrustlineStatus.UNKNOWN: TrustlineError.REASON_UNKNOWN,
         }
+        raise TrustlineError(
+            reason=reason_map[result.status],
+            address=address,
+            asset_code=asset_code,
+        )

--- a/tests/ STELLAR_INTEGRATION.md
+++ b/tests/ STELLAR_INTEGRATION.md
@@ -1,0 +1,70 @@
+# Stellar Integration Guide
+
+## Network identity and testnet/mainnet separation (#286)
+
+This service is configured for a **single** Stellar network per deployment. Cross-network operations are rejected at the adapter layer and audit-logged.
+
+### Configuration
+
+Set `STELLAR_NETWORK` in your environment:
+
+```
+STELLAR_NETWORK=testnet   # development / staging
+STELLAR_NETWORK=mainnet   # production
+```
+
+The application derives the Horizon URL and network passphrase automatically. You may override the Horizon URL via `STELLAR_HORIZON_URL` if using a private instance.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `STELLAR_NETWORK` | No | `testnet` | `testnet` or `mainnet` |
+| `STELLAR_HORIZON_URL` | No | canonical URL | Override Horizon base URL |
+| `WALLET_HEALTH_RATE_LIMIT_SECONDS` | No | `60` | Minimum seconds between health checks per wallet |
+
+### Network mismatch behaviour
+
+When an operation carries a `wallet_network` that differs from `STELLAR_NETWORK`, the service:
+
+1. Logs a `WARNING` with `audit=True` metadata.
+2. Returns `HTTP 409 Conflict` with `code: NETWORK_MISMATCH`.
+3. Does **not** submit any transaction.
+
+This prevents accidental mainnet payments from a testnet deployment and vice-versa.
+
+---
+
+## Trustline verification (#285)
+
+Before any payout is submitted, the service verifies that the recipient wallet has an active trustline for the payment asset with a non-zero limit.
+
+| Trustline state | Reason code | HTTP status | Retryable? |
+|---|---|---|---|
+| Missing | `TRUSTLINE_MISSING` | 402 | No — recipient must add trustline |
+| Limit zero | `TRUSTLINE_LIMIT_ZERO` | 402 | No — recipient must raise limit |
+| Horizon unreachable | `TRUSTLINE_CHECK_FAILED` | 402 | Yes — transient |
+
+---
+
+## Wallet health endpoint (#288)
+
+```
+GET /api/v1/wallets/{address}/health
+```
+
+Returns operational readiness for a wallet:
+
+```json
+{
+  "address": "GAAZI4...",
+  "overall": "ready",
+  "checked_at": "2025-01-01T00:00:00Z",
+  "funding": { "state": "ready", "checked_at": "...", "details": { "xlm_balance": "100.0" } },
+  "trustline": { "state": "ready", "checked_at": "...", "details": { "asset_code": "USDC", ... } },
+  "network_reachable": { "state": "ready", "checked_at": "...", "details": { "horizon_url": "..." } },
+  "rate_limited": false
+}
+```
+
+Checks are rate-limited (default 60 s). Pass `?force=true` to bypass.
+
+The `/readyz` readiness probe aggregates all tracked wallet health records and returns `HTTP 503` if any wallet is `not_ready`.


### PR DESCRIPTION
Closes #284, 
Closes #285, 
Closes #286, 
Closes #288

#284 - Wallet address canonicalization

app/utils/wallet_address.py exports canonicalize() (strips, uppercases, validates Stellar G-address regex) and is_valid(). Raises WalletAddressError with typed codes WALLET_ADDRESS_EMPTY and WALLET_ADDRESS_INVALID for consistent API error shapes. Wallet SQLAlchemy model uses an @validates("address") hook so every ORM write is canonical. All wallet endpoints run addresses through canonicalize() before use.

#285 - Trustline gate before payout

SLAAdapter.check_trustline() does a non-destructive Horizon account GET and inspects balances. Returns a TrustlineResult with READY / MISSING / LIMIT_ZERO / UNKNOWN states. assert_trustline_ready() raises TrustlineError with non-retryable reason codes (TRUSTLINE_MISSING, TRUSTLINE_LIMIT_ZERO, TRUSTLINE_CHECK_FAILED). SLAService.execute_payout() calls this gate before any submission. The /payout endpoint maps TrustlineError to HTTP 402 with the reason code. The /health endpoint surfaces trustline readiness alongside funding and network checks.

#286 - Network mismatch safeguards

app/core/config.py makes STELLAR_NETWORK (testnet | mainnet) the single source of truth, deriving the Horizon URL and network passphrase automatically. SLAAdapter.assert_network() compares the operation's wallet_network against settings.STELLAR_NETWORK.value, raises NetworkMismatchError, and audit-logs every rejection (audit=True). The /payout endpoint returns HTTP 409 Conflict on mismatch. docs/STELLAR_INTEGRATION.md documents all env vars and behaviours.

#288 - Wallet health endpoint

app/services/metrics.py provides WalletHealthMetrics - an async-safe in-process cache of HealthCheckResult records per wallet with WALLET_HEALTH_RATE_LIMIT_SECONDS rate limiting. GET /api/v1/wallets/{address}/health runs three non-destructive checks (network reachability, XLM funding, USDC trustline), caches results, and returns overall readiness plus per-check details and timestamps. ?force=true bypasses the rate limit. GET /readyz aggregates all tracked wallet records into the Kubernetes readiness probe, returning HTTP 503 if any wallet is not_ready.
