### PR TITLE
feat: outage state machine, payment idempotency cleanup, wallet cache stampede prevention (#421, #422, #423)

### DIFF
--- a/app/api/v1/endpoints/outages.py
+++ b/app/api/v1/endpoints/outages.py
@@ -8,6 +8,7 @@ from app.models import BulkOutageCreate, Outage, OutageCreate, OutageUpdate
 from app.repositories.outage_repository import OutageRepository
 from app.repositories.payment_repository import PaymentRepository
 from app.repositories.sla_repository import SLARepository
+from app.core.outage_state_machine import OutageStateMachine
 from app.services.audit_log import audit_log
 from app.services.contracts import SLAContractAdapter, translate_contract_result
 from app.services.webhook_service import trigger_sla_violation_webhooks
@@ -84,6 +85,14 @@ def update_outage(outage_id: str, payload: OutageUpdate, db: Session = Depends(g
     if not existing:
         raise HTTPException(status_code=404, detail="Outage not found")
 
+    if payload.status is not None:
+        try:
+            OutageStateMachine.transition(
+                outage_id, existing.status, payload.status.value
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     updated = repo.update(outage_id, payload)
     return updated
 
@@ -102,6 +111,17 @@ def delete_outage(outage_id: str, db: Session = Depends(get_db)):
 @router.post("/{outage_id}/resolve")
 def resolve_outage(outage_id: str, payload: ResolveOutageRequest, db: Session = Depends(get_db)):
     repo = OutageRepository(db)
+    outage = repo.get(outage_id)
+    if not outage:
+        raise HTTPException(status_code=404, detail="Outage not found")
+
+    try:
+        OutageStateMachine.transition(
+            outage_id, outage.status, "resolved"
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     outage = repo.resolve(outage_id, payload.mttr_minutes)
     if not outage:
         raise HTTPException(status_code=404, detail="Outage not found")
@@ -164,3 +184,17 @@ def recompute_sla(outage_id: str, db: Session = Depends(get_db)):
 
     audit_log.log("sla_recomputed", {"id": outage.id})
     return {"sla": stored_sla, "payment": payment}
+
+
+@router.get("/{outage_id}/transitions")
+def get_valid_transitions(outage_id: str, db: Session = Depends(get_db)):
+    repo = OutageRepository(db)
+    outage = repo.get(outage_id)
+    if not outage:
+        raise HTTPException(status_code=404, detail="Outage not found")
+    valid = OutageStateMachine.get_valid_next_states(outage.status)
+    return {
+        "outage_id": outage_id,
+        "current_status": outage.status,
+        "valid_next_states": sorted(valid),
+    }

--- a/app/api/v1/endpoints/payments.py
+++ b/app/api/v1/endpoints/payments.py
@@ -1,11 +1,18 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.models.payment import PaginatedPayments, PaymentTransaction
 from app.repositories.payment_repository import PaymentRepository
+from app.services.idempotency_service import IdempotencyService
 
 router = APIRouter()
+
+
+@router.get("/idempotency/metrics")
+def idempotency_metrics(db: Session = Depends(get_db)):
+    service = IdempotencyService(db)
+    return service.get_metrics()
 
 
 @router.get("/", response_model=PaginatedPayments)
@@ -38,3 +45,46 @@ def get_payment(transaction_id: str, db: Session = Depends(get_db)):
     if not payment:
         raise HTTPException(status_code=404, detail="Payment not found")
     return payment
+
+
+@router.post("/{outage_id}/create", response_model=PaymentTransaction)
+def create_payment_for_outage(
+    outage_id: str,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    idempotency_key = request.headers.get("X-Idempotency-Key")
+    service = IdempotencyService(db)
+
+    if idempotency_key:
+        cached = service.lookup(idempotency_key)
+        if cached is not None:
+            response.status_code = cached["status_code"]
+            return cached["response_json"]
+
+    repo = PaymentRepository(db)
+    from app.models.sla import SLAResult
+    from datetime import datetime
+
+    payment = PaymentTransaction(
+        id=f"pay_{outage_id[:12]}",
+        transaction_hash=f"outage-{outage_id}",
+        type="sla_settlement",
+        amount=0.0,
+        asset_code="USDC",
+        from_address="SYSTEM_POOL",
+        to_address="OUTAGE_SETTLEMENT",
+        status="pending",
+        outage_id=outage_id,
+        sla_result_id=None,
+        created_at=datetime.utcnow(),
+        confirmed_at=None,
+    )
+    created = repo.create(payment)
+
+    if idempotency_key:
+        service.store(idempotency_key, created.model_dump(mode="json"), 201)
+
+    response.status_code = 201
+    return created

--- a/app/api/v1/endpoints/wallets.py
+++ b/app/api/v1/endpoints/wallets.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Request, Response, status
 
 from app.models.wallet import (
     Wallet,
@@ -28,6 +28,11 @@ def wallets_ping():
     return {"message": "wallets ok"}
 
 
+@router.get("/metrics")
+def wallet_cache_metrics():
+    return WalletRegistry.get_cache_metrics()
+
+
 @router.get("/{user_id}", response_model=Wallet)
 def get_wallet(user_id: str):
     wallet = WalletRegistry.get_wallet(user_id)
@@ -45,8 +50,9 @@ def get_wallet_status(user_id: str):
 
 
 @router.get("/{address}/balance", response_model=WalletBalanceResponse)
-def get_wallet_balance(address: str):
-    balance = WalletRegistry.get_balance(address)
+def get_wallet_balance(address: str, response: Response):
+    balance, cache_status = WalletRegistry.get_balance(address)
     if not balance:
         raise HTTPException(status_code=404, detail="Wallet not found")
+    response.headers["X-Cache-Status"] = cache_status
     return balance

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,6 +17,13 @@ class Settings(BaseSettings):
     STELLAR_NETWORK: str = "testnet"
     CONTRACT_EXECUTION_MODE: str = "local_adapter"
 
+    IDEMPOTENCY_KEY_TTL_HOURS: int = 24
+
+    WALLET_CACHE_LOCK_TIMEOUT: int = 5
+    WALLET_CACHE_LOCK_PREFIX: str = "wallet:lock:"
+    WALLET_CACHE_TTL: int = 300
+    REDIS_URL: str = "redis://localhost:6379/1"
+
     class Config:
         env_file = ".env"
 

--- a/app/core/outage_state_machine.py
+++ b/app/core/outage_state_machine.py
@@ -1,0 +1,50 @@
+import logging
+from typing import Dict, Set
+
+from app.services.audit_log import audit_log
+
+logger = logging.getLogger(__name__)
+
+VALID_TRANSITIONS: Dict[str, Set[str]] = {
+    "investigating": {"active", "resolved"},
+    "active": {"resolved"},
+    "resolved": set(),
+}
+
+
+class OutageStateMachine:
+    @staticmethod
+    def can_transition(from_status: str, to_status: str) -> bool:
+        return to_status in VALID_TRANSITIONS.get(from_status, set())
+
+    @staticmethod
+    def validate_transition(from_status: str, to_status: str) -> None:
+        if from_status not in VALID_TRANSITIONS:
+            raise ValueError(f"Unknown outage status: {from_status}")
+        if not OutageStateMachine.can_transition(from_status, to_status):
+            raise ValueError(
+                f"Invalid transition: {from_status} -> {to_status}. "
+                f"Valid transitions from '{from_status}': "
+                f"{VALID_TRANSITIONS[from_status] or '(none)'}"
+            )
+
+    @staticmethod
+    def get_valid_next_states(from_status: str) -> set:
+        if from_status not in VALID_TRANSITIONS:
+            raise ValueError(f"Unknown outage status: {from_status}")
+        return VALID_TRANSITIONS[from_status].copy()
+
+    @staticmethod
+    def transition(outage_id: str, from_status: str, to_status: str) -> None:
+        OutageStateMachine.validate_transition(from_status, to_status)
+        logger.info(
+            "Outage %s transition: %s -> %s", outage_id, from_status, to_status
+        )
+        audit_log.log(
+            "outage_status_transition",
+            {
+                "outage_id": outage_id,
+                "from_status": from_status,
+                "to_status": to_status,
+            },
+        )

--- a/app/models/orm/__init__.py
+++ b/app/models/orm/__init__.py
@@ -1,6 +1,7 @@
 from app.models.orm.outage import OutageORM
 from app.models.orm.sla import SLAResultORM
 from app.models.orm.payment import PaymentTransactionORM
+from app.models.orm.idempotency import IdempotencyKeyORM
 from app.models.sla_dispute import SLADispute
 
-__all__ = ["OutageORM", "SLAResultORM", "PaymentTransactionORM", "SLADispute"]
+__all__ = ["OutageORM", "SLAResultORM", "PaymentTransactionORM", "IdempotencyKeyORM", "SLADispute"]

--- a/app/models/orm/idempotency.py
+++ b/app/models/orm/idempotency.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Integer, String, Text
+
+from app.db.base import Base
+
+
+class IdempotencyKeyORM(Base):
+    __tablename__ = "idempotency_keys"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    key = Column(String(255), nullable=False, unique=True, index=True)
+    response_json = Column(Text, nullable=False)
+    status_code = Column(Integer, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    expires_at = Column(DateTime, nullable=False, index=True)

--- a/app/services/idempotency_service.py
+++ b/app/services/idempotency_service.py
@@ -1,0 +1,85 @@
+import json
+import logging
+from datetime import datetime, timedelta, UTC
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.orm.idempotency import IdempotencyKeyORM
+
+logger = logging.getLogger(__name__)
+
+
+class IdempotencyMetrics:
+    hits: int = 0
+    misses: int = 0
+    stored: int = 0
+    deleted: int = 0
+    expired_cleaned: int = 0
+
+
+metrics = IdempotencyMetrics()
+
+
+class IdempotencyService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def lookup(self, key: str) -> dict | None:
+        row = (
+            self.db.query(IdempotencyKeyORM)
+            .filter(IdempotencyKeyORM.key == key)
+            .first()
+        )
+        if row is None:
+            metrics.misses += 1
+            return None
+        if row.expires_at < datetime.now(UTC):
+            metrics.misses += 1
+            self.db.delete(row)
+            self.db.commit()
+            return None
+        metrics.hits += 1
+        return {
+            "response_json": json.loads(row.response_json),
+            "status_code": row.status_code,
+        }
+
+    def store(
+        self, key: str, response_body: dict, status_code: int
+    ) -> None:
+        ttl_hours = settings.IDEMPOTENCY_KEY_TTL_HOURS
+        now = datetime.now(UTC)
+        row = IdempotencyKeyORM(
+            key=key,
+            response_json=json.dumps(response_body),
+            status_code=status_code,
+            created_at=now,
+            expires_at=now + timedelta(hours=ttl_hours),
+        )
+        self.db.merge(row)
+        self.db.commit()
+        metrics.stored += 1
+
+    def cleanup_expired(self) -> int:
+        now = datetime.now(UTC)
+        expired = (
+            self.db.query(IdempotencyKeyORM)
+            .filter(IdempotencyKeyORM.expires_at < now)
+            .all()
+        )
+        count = len(expired)
+        for row in expired:
+            self.db.delete(row)
+        self.db.commit()
+        metrics.expired_cleaned += count
+        logger.info("Cleaned up %d expired idempotency keys", count)
+        return count
+
+    def get_metrics(self) -> dict:
+        return {
+            "hits": metrics.hits,
+            "misses": metrics.misses,
+            "stored": metrics.stored,
+            "expired_cleaned": metrics.expired_cleaned,
+        }

--- a/app/services/wallet_registry.py
+++ b/app/services/wallet_registry.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import asyncio
+import logging
+import time
 from datetime import datetime, UTC
 from uuid import uuid4
 
+import redis
+
+from app.core.config import settings
 from app.models.wallet import (
     AssetBalance,
     Wallet,
@@ -13,10 +19,37 @@ from app.models.wallet import (
     WalletStatusResponse,
 )
 
+logger = logging.getLogger(__name__)
+
+
+class WalletCacheMetrics:
+    cache_hits: int = 0
+    cache_misses: int = 0
+    lock_acquisitions: int = 0
+    lock_timeouts: int = 0
+
+
+_wallet_cache_metrics = WalletCacheMetrics()
+
+_balance_cache: dict[str, tuple[WalletBalanceResponse, float]] = {}
+
 
 class WalletRegistry:
     _wallets_by_user: dict[str, Wallet] = {}
     _wallets_by_address: dict[str, Wallet] = {}
+    _redis_client: redis.Redis | None = None
+
+    @classmethod
+    def _get_redis(cls) -> redis.Redis | None:
+        if cls._redis_client is None:
+            try:
+                cls._redis_client = redis.Redis.from_url(
+                    settings.REDIS_URL, decode_responses=True, socket_timeout=2
+                )
+                cls._redis_client.ping()
+            except Exception:
+                cls._redis_client = None
+        return cls._redis_client
 
     @staticmethod
     def _now() -> datetime:
@@ -25,6 +58,53 @@ class WalletRegistry:
     @classmethod
     def _build_public_key(cls) -> str:
         return f"G{uuid4().hex.upper()}"
+
+    @classmethod
+    def _try_acquire_lock(cls, wallet_key: str) -> bool:
+        r = cls._get_redis()
+        if r is None:
+            return True
+        lock_key = f"{settings.WALLET_CACHE_LOCK_PREFIX}{wallet_key}"
+        for attempt in range(3):
+            acquired = r.set(
+                lock_key, "1", nx=True, ex=settings.WALLET_CACHE_LOCK_TIMEOUT
+            )
+            if acquired:
+                _wallet_cache_metrics.lock_acquisitions += 1
+                return True
+            _wallet_cache_metrics.lock_timeouts += 1
+            if attempt < 2:
+                time.sleep(0.1)
+        return False
+
+    @classmethod
+    def _release_lock(cls, wallet_key: str) -> None:
+        r = cls._get_redis()
+        if r is None:
+            return
+        lock_key = f"{settings.WALLET_CACHE_LOCK_PREFIX}{wallet_key}"
+        try:
+            r.delete(lock_key)
+        except Exception:
+            pass
+
+    @classmethod
+    def _get_cached_balance(
+        cls, address: str
+    ) -> WalletBalanceResponse | None:
+        cached = _balance_cache.get(address)
+        if cached is None:
+            return None
+        response, ts = cached
+        if time.time() - ts > settings.WALLET_CACHE_TTL:
+            return None
+        return response
+
+    @classmethod
+    def _set_cached_balance(
+        cls, address: str, response: WalletBalanceResponse
+    ) -> None:
+        _balance_cache[address] = (response, time.time())
 
     @classmethod
     def create_wallet(cls, payload: WalletCreateRequest) -> WalletCreateResponse:
@@ -75,27 +155,54 @@ class WalletRegistry:
         return cls._wallets_by_user.get(user_id)
 
     @classmethod
-    def get_balance(cls, address: str) -> WalletBalanceResponse | None:
+    def get_balance(cls, address: str) -> tuple[WalletBalanceResponse | None, str]:
         wallet = cls._wallets_by_address.get(address)
         if not wallet:
-            return None
+            return None, "miss"
 
-        xlm_balance = "1.0000000" if wallet.funded else "0.0000000"
-        balances = {
-            "XLM": AssetBalance(balance=xlm_balance, asset_type="native"),
-        }
-        if wallet.trustline_ready:
-            balances["USDC"] = AssetBalance(
-                balance="0.0000000",
-                asset_type="credit_alphanum4",
-                asset_code="USDC",
-                asset_issuer="TEST_ISSUER",
+        cached = cls._get_cached_balance(address)
+        if cached is not None:
+            _wallet_cache_metrics.cache_hits += 1
+            return cached, "hit"
+
+        _wallet_cache_metrics.cache_misses += 1
+        lock_acquired = cls._try_acquire_lock(address)
+        if not lock_acquired:
+            cached = cls._get_cached_balance(address)
+            if cached is not None:
+                return cached, "stale"
+            return None, "miss"
+
+        try:
+            xlm_balance = "1.0000000" if wallet.funded else "0.0000000"
+            balances = {
+                "XLM": AssetBalance(balance=xlm_balance, asset_type="native"),
+            }
+            if wallet.trustline_ready:
+                balances["USDC"] = AssetBalance(
+                    balance="0.0000000",
+                    asset_type="credit_alphanum4",
+                    asset_code="USDC",
+                    asset_issuer="TEST_ISSUER",
+                )
+            response = WalletBalanceResponse(
+                address=address,
+                balances=balances,
+                last_updated=cls._now(),
             )
-        return WalletBalanceResponse(
-            address=address,
-            balances=balances,
-            last_updated=cls._now(),
-        )
+            cls._set_cached_balance(address, response)
+            return response, "refreshing"
+        finally:
+            cls._release_lock(address)
+
+    @classmethod
+    def get_cache_metrics(cls) -> dict:
+        return {
+            "cache_hits": _wallet_cache_metrics.cache_hits,
+            "cache_misses": _wallet_cache_metrics.cache_misses,
+            "lock_acquisitions": _wallet_cache_metrics.lock_acquisitions,
+            "lock_timeouts": _wallet_cache_metrics.lock_timeouts,
+        }
 
     @classmethod
     def get_status(cls, user_id: str) -> WalletStatusResponse | None:

--- a/app/tasks/celery_app.py
+++ b/app/tasks/celery_app.py
@@ -8,6 +8,7 @@ celery_app = Celery(
     include=[
         "app.tasks.sla_tasks",
         "app.tasks.webhook_tasks",
+        "app.tasks.idempotency_tasks",
     ],
 )
 
@@ -28,6 +29,10 @@ celery_app.conf.update(
         "retry-pending-webhook-deliveries": {
             "task": "app.tasks.webhook_tasks.retry_pending_webhook_deliveries",
             "schedule": 60.0,  # every 60 seconds
+        },
+        "cleanup-expired-idempotency-keys": {
+            "task": "app.tasks.idempotency_tasks.cleanup_expired_idempotency_keys",
+            "schedule": 3600.0,  # every hour
         },
     },
 )

--- a/app/tasks/idempotency_tasks.py
+++ b/app/tasks/idempotency_tasks.py
@@ -1,0 +1,30 @@
+import logging
+from typing import Dict, Any
+
+from celery import Task
+
+from app.tasks.celery_app import celery_app
+from app.db.session import SessionLocal
+
+logger = logging.getLogger(__name__)
+
+
+class IdempotencyCleanupTask(Task):
+    abstract = True
+
+
+@celery_app.task(
+    bind=True,
+    base=IdempotencyCleanupTask,
+    name="app.tasks.idempotency_tasks.cleanup_expired_idempotency_keys",
+)
+def cleanup_expired_idempotency_keys(self) -> Dict[str, Any]:
+    db = SessionLocal()
+    try:
+        from app.services.idempotency_service import IdempotencyService
+        service = IdempotencyService(db)
+        count = service.cleanup_expired()
+        logger.info("Idempotency cleanup completed: %d keys removed", count)
+        return {"cleaned": count}
+    finally:
+        db.close()


### PR DESCRIPTION
## Changes

### #421 - Outage status transition state machine
- `OutageStateMachine` with validated transitions
- Invalid transitions return 400 with descriptive error
- GET `/outages/{id}/transitions` shows valid next states

### #422 - Payment idempotency key expiry and cleanup
- Idempotency key storage with configurable TTL (default 24h)
- Celery task runs hourly to clean expired keys
- Metrics: hit/miss/cleanup counts

### #423 - Wallet balance cache stampede prevention
- Redis distributed locking (SET NX EX, 3 retries, 100ms backoff)
- `X-Cache-Status` response header
- Cache hit/miss/lock metrics endpoint

Closes #421, Closes #422, Closes #423