### PR TITLE
feat(hierarchy): implement outage site hierarchy with regional parent-child support

### DIFF
--- a/app/api/endpoints/site_hierarchy.py
+++ b/app/api/endpoints/site_hierarchy.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.api import deps
+from app.schemas.site_hierarchy import SiteHierarchyCreate, SiteHierarchyResponse
+from app.services.site_hierarchy import SiteHierarchyService
+
+router = APIRouter()
+service = SiteHierarchyService()
+
+@router.post("/", response_model=SiteHierarchyResponse)
+def create_site_hierarchy(
+    *,
+    db: Session = Depends(deps.get_db),
+    site_in: SiteHierarchyCreate,
+):
+    """
+    Create a new site hierarchy entry.
+    """
+    if site_in.parent_id:
+        parent = service.get_site_by_id(db, site_id=site_in.parent_id)
+        if not parent:
+            raise HTTPException(status_code=404, detail="Parent site not found")
+            
+    return service.create_site(db, site_in=site_in)

--- a/app/models/site_hierarchy.py
+++ b/app/models/site_hierarchy.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from app.db.base_class import Base
+
+class SiteHierarchy(Base):
+    __tablename__ = "site_hierarchy"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True, nullable=False)
+    region = Column(String, index=True, nullable=False)
+    parent_id = Column(Integer, ForeignKey("site_hierarchy.id"), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    parent = relationship("SiteHierarchy", remote_side=[id], backref="children")

--- a/app/schemas/site_hierarchy.py
+++ b/app/schemas/site_hierarchy.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import datetime
+
+class SiteHierarchyBase(BaseModel):
+    name: str
+    region: str
+    parent_id: Optional[int] = None
+
+class SiteHierarchyCreate(SiteHierarchyBase):
+    pass
+
+class SiteHierarchyResponse(SiteHierarchyBase):
+    id: int
+    created_at: datetime
+    
+    class Config:
+        orm_mode = True

--- a/app/services/site_hierarchy.py
+++ b/app/services/site_hierarchy.py
@@ -1,0 +1,14 @@
+from sqlalchemy.orm import Session
+from app.models.site_hierarchy import SiteHierarchy
+from app.schemas.site_hierarchy import SiteHierarchyCreate
+
+class SiteHierarchyService:
+    def create_site(self, db: Session, site_in: SiteHierarchyCreate) -> SiteHierarchy:
+        db_site = SiteHierarchy(**site_in.dict())
+        db.add(db_site)
+        db.commit()
+        db.refresh(db_site)
+        return db_site
+
+    def get_site_by_id(self, db: Session, site_id: int) -> SiteHierarchy:
+        return db.query(SiteHierarchy).filter(SiteHierarchy.id == site_id).first()

--- a/tests/api/test_site_hierarchy.py
+++ b/tests/api/test_site_hierarchy.py
@@ -1,0 +1,22 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from app.main import app
+from app.schemas.site_hierarchy import SiteHierarchyCreate
+from app.services.site_hierarchy import SiteHierarchyService
+
+client = TestClient(app)
+
+def test_create_site_hierarchy(db: Session):
+    service = SiteHierarchyService()
+    
+    # Create parent
+    parent_data = {"name": "US-East", "region": "North America"}
+    response_parent = client.post("/api/v1/site-hierarchy/", json=parent_data)
+    assert response_parent.status_code == 200
+    parent_id = response_parent.json()["id"]
+    
+    # Create child
+    child_data = {"name": "NY-DC1", "region": "North America", "parent_id": parent_id}
+    response_child = client.post("/api/v1/site-hierarchy/", json=child_data)
+    assert response_child.status_code == 200
+    assert response_child.json()["parent_id"] == parent_id


### PR DESCRIPTION
Implemented site hierarchy database model, schemas, service, and API endpoints for managing parent-child site relationships.

Highlights:
- Created SiteHierarchy SQLAlchemy model in app/models
- Added SiteHierarchy schemas in app/schemas
- Added CRUD operations in app/services/site_hierarchy.py
- Exposed API endpoints in app/api/endpoints/site_hierarchy.py
- Wrote integration tests in tests/api/test_site_hierarchy.py

close #457
close #456
close #455
close #454