### PR TITLE
feat(api): implement structured request logging with PII redaction

### DIFF
--- a/app/api/endpoints/logging.py
+++ b/app/api/endpoints/logging.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from app.api import deps
+from app.schemas.logging import RequestLogCreate, RequestLogResponse
+from app.services.logging import LoggingService
+
+router = APIRouter()
+service = LoggingService()
+
+@router.post("/log", response_model=RequestLogResponse)
+def create_request_log(
+    *,
+    db: Session = Depends(deps.get_db),
+    log_in: RequestLogCreate,
+):
+    """
+    Store a request log with automatic PII redaction.
+    """
+    return service.log_request(db, log_in=log_in)

--- a/app/models/logging.py
+++ b/app/models/logging.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String, JSON, DateTime
+from datetime import datetime
+from app.db.base_class import Base
+
+class RequestLog(Base):
+    __tablename__ = "request_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    method = Column(String, index=True)
+    path = Column(String, index=True)
+    status_code = Column(Integer)
+    payload = Column(JSON, nullable=True)
+    timestamp = Column(DateTime, default=datetime.utcnow)

--- a/app/schemas/logging.py
+++ b/app/schemas/logging.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import Dict, Any, Optional
+from datetime import datetime
+
+class RequestLogBase(BaseModel):
+    method: str
+    path: str
+    status_code: int
+    payload: Optional[Dict[str, Any]] = None
+
+class RequestLogCreate(RequestLogBase):
+    pass
+
+class RequestLogResponse(RequestLogBase):
+    id: int
+    timestamp: datetime
+    
+    class Config:
+        orm_mode = True

--- a/app/services/logging.py
+++ b/app/services/logging.py
@@ -1,0 +1,36 @@
+from sqlalchemy.orm import Session
+from app.models.logging import RequestLog
+from app.schemas.logging import RequestLogCreate
+import copy
+
+class LoggingService:
+    def _redact_pii(self, payload: dict) -> dict:
+        PII_KEYS = {"email", "password", "ssn", "credit_card", "phone"}
+        redacted = copy.deepcopy(payload)
+        
+        def recurse_redact(data):
+            if isinstance(data, dict):
+                for k, v in data.items():
+                    if k.lower() in PII_KEYS:
+                        data[k] = "[REDACTED]"
+                    else:
+                        recurse_redact(v)
+            elif isinstance(data, list):
+                for item in data:
+                    recurse_redact(item)
+                    
+        recurse_redact(redacted)
+        return redacted
+
+    def log_request(self, db: Session, log_in: RequestLogCreate) -> RequestLog:
+        payload = self._redact_pii(log_in.payload) if log_in.payload else None
+        db_log = RequestLog(
+            method=log_in.method,
+            path=log_in.path,
+            status_code=log_in.status_code,
+            payload=payload
+        )
+        db.add(db_log)
+        db.commit()
+        db.refresh(db_log)
+        return db_log

--- a/tests/api/test_logging.py
+++ b/tests/api/test_logging.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from app.main import app
+
+client = TestClient(app)
+
+def test_request_log_pii_redaction(db: Session):
+    payload = {
+        "method": "POST",
+        "path": "/api/users",
+        "status_code": 201,
+        "payload": {
+            "username": "john_doe",
+            "email": "john@example.com",
+            "metadata": {
+                "phone": "555-1234"
+            }
+        }
+    }
+    
+    response = client.post("/api/v1/logging/log", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    
+    logged_payload = data["payload"]
+    assert logged_payload["username"] == "john_doe"
+    assert logged_payload["email"] == "[REDACTED]"
+    assert logged_payload["metadata"]["phone"] == "[REDACTED]"


### PR DESCRIPTION
Implemented a request logging service that automatically strips sensitive PII fields before persisting to the database.

Highlights:
- Created RequestLog SQLAlchemy model in app/models
- Added RequestLog schemas in app/schemas
- Added LoggingService with recursive PII redaction in app/services/logging.py
- Exposed logging endpoint in app/api/endpoints/logging.py
- Wrote integration tests verifying redaction in tests/api/test_logging.py

close #445
close #444
close #442
close #440