### PR TITLE
feat(api): implement bulk outage creation endpoint with transaction rollback

### DIFF
--- a/app/api/endpoints/outage_bulk.py
+++ b/app/api/endpoints/outage_bulk.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from app.api import deps
+from app.schemas.outage_bulk import BulkOutageCreate, BulkOutageResponse
+from app.services.outage_bulk import OutageBulkService
+
+router = APIRouter()
+service = OutageBulkService()
+
+@router.post("/bulk", response_model=BulkOutageResponse)
+def create_bulk_outages(
+    *,
+    db: Session = Depends(deps.get_db),
+    payload: BulkOutageCreate,
+):
+    """
+    Create multiple outage records in a single database transaction.
+    Rolls back entirely if any record fails.
+    """
+    return service.create_bulk_outages(db, payload=payload)

--- a/app/models/outage_bulk.py
+++ b/app/models/outage_bulk.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String, DateTime
+from datetime import datetime
+from app.db.base_class import Base
+
+class OutageRecord(Base):
+    __tablename__ = "outage_records"
+
+    id = Column(Integer, primary_key=True, index=True)
+    service_name = Column(String, index=True, nullable=False)
+    description = Column(String, nullable=False)
+    severity = Column(String, index=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/app/schemas/outage_bulk.py
+++ b/app/schemas/outage_bulk.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import List, Optional
+from datetime import datetime
+
+class OutageItemCreate(BaseModel):
+    service_name: str
+    description: str
+    severity: str
+
+class BulkOutageCreate(BaseModel):
+    outages: List[OutageItemCreate]
+
+class BulkOutageResponse(BaseModel):
+    successful: int
+    failed: int
+    message: str

--- a/app/services/outage_bulk.py
+++ b/app/services/outage_bulk.py
@@ -1,0 +1,30 @@
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+from app.models.outage_bulk import OutageRecord
+from app.schemas.outage_bulk import BulkOutageCreate, BulkOutageResponse
+
+class OutageBulkService:
+    def create_bulk_outages(self, db: Session, payload: BulkOutageCreate) -> BulkOutageResponse:
+        try:
+            records = [
+                OutageRecord(
+                    service_name=item.service_name,
+                    description=item.description,
+                    severity=item.severity
+                )
+                for item in payload.outages
+            ]
+            db.add_all(records)
+            db.commit()
+            return BulkOutageResponse(
+                successful=len(records),
+                failed=0,
+                message="Successfully created bulk outages"
+            )
+        except SQLAlchemyError as e:
+            db.rollback()
+            return BulkOutageResponse(
+                successful=0,
+                failed=len(payload.outages),
+                message=f"Database transaction rolled back due to error: {str(e)}"
+            )

--- a/tests/api/test_outage_bulk.py
+++ b/tests/api/test_outage_bulk.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from app.main import app
+
+client = TestClient(app)
+
+def test_bulk_outage_creation(db: Session):
+    payload = {
+        "outages": [
+            {
+                "service_name": "API Gateway",
+                "description": "High latency in region US-East",
+                "severity": "HIGH"
+            },
+            {
+                "service_name": "Redis Cache",
+                "description": "Cache misses spiking",
+                "severity": "MEDIUM"
+            }
+        ]
+    }
+    
+    response = client.post("/api/v1/outages/bulk", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["successful"] == 2
+    assert data["failed"] == 0
+    assert "Successfully" in data["message"]


### PR DESCRIPTION
Implemented a bulk creation endpoint for outage records utilizing a single database transaction to guarantee atomicity.

Highlights:
- Created OutageRecord SQLAlchemy model in app/models
- Added BulkOutage schemas in app/schemas
- Added OutageBulkService with transaction management in app/services/outage_bulk.py
- Exposed REST endpoints in app/api/endpoints/outage_bulk.py
- Wrote integration tests covering successful bulk inserts in tests/api/test_outage_bulk.py

close #431
close #430
close #429
close #428