### PR TITLE
feat: [BE-W5-078] Request guardrail parity across JSON and multipart routes

### DIFF
--- a/app/api/upload_router.py
+++ b/app/api/upload_router.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends, Request, UploadFile, File
+from app.core.guardrails import check_payload_size
+from pydantic import BaseModel
+
+router = APIRouter()
+
+class JsonPayload(BaseModel):
+    data: str
+
+@router.post("/upload/json", dependencies=[Depends(check_payload_size)])
+async def upload_json(payload: JsonPayload):
+    return {"status": "success", "size": len(payload.data)}
+
+@router.post("/upload/multipart", dependencies=[Depends(check_payload_size)])
+async def upload_multipart(file: UploadFile = File(...)):
+    return {"status": "success", "filename": file.filename}

--- a/app/core/guardrails.py
+++ b/app/core/guardrails.py
@@ -1,0 +1,8 @@
+from fastapi import Request, HTTPException
+
+MAX_CONTENT_LENGTH = 10 * 1024 * 1024 # 10MB
+
+async def check_payload_size(request: Request):
+    content_length = request.headers.get('content-length')
+    if content_length and int(content_length) > MAX_CONTENT_LENGTH:
+        raise HTTPException(status_code=413, detail="Payload too large")

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,5 @@
+import asyncio
+from app.core.guardrails import check_payload_size, MAX_CONTENT_LENGTH
+
+def test_constants():
+    assert MAX_CONTENT_LENGTH == 10485760


### PR DESCRIPTION
This PR implements the [BE-W5-078] Request guardrail parity across JSON and multipart routes feature.\n\ncloses #339, closes #338, closes #337, closes #336