### PR TITLE
feat: BE-W5-055 worker concurrency tuning profile + DB/broker guardrails

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -132,6 +132,27 @@ class Settings(BaseSettings):
     CELERY_STRICT_QUEUE_BINDINGS: bool = True
     # Timeout in seconds for the startup queue-binding probe.
     CELERY_QUEUE_PROBE_TIMEOUT_SECONDS: float = 5.0
+
+    # BE-W5-055: Worker concurrency tuning profile & safeguards
+    # Logical environment name; selects the per-env profile from
+    # concurrency_guardrails.PROFILES. Operators may also override any
+    # concrete value below (concurrency, max tasks per child, broker cap,
+    # broker alert threshold).
+    APP_ENV: str = "dev"
+    # Optional overrides for the per-env profile. ``None`` means "use profile".
+    CELERY_WORKER_CONCURRENCY: Optional[int] = None
+    CELERY_MAX_TASKS_PER_CHILD: Optional[int] = None
+    # Safe upper bound on simultaneous broker (Redis) connections.
+    BROKER_MAX_CONNECTIONS: int = 100
+    # Fraction (0 < x < 1) of BROKER_MAX_CONNECTIONS at which the periodic
+    # guardrail emits an alert and flips the gauge to 1.0.
+    BROKER_SATURATION_THRESHOLD: float = 0.8
+    # Fraction (0 < x < DB_POOL_SATURATION_THRESHOLD) at which the periodic
+    # guardrail **alerts** — strictly below the saturation threshold that
+    # PoolSaturationMiddleware uses to start rejecting requests (530/503).
+    # This is what "guardrail alerts fire before saturation failures" means
+    # in BE-W5-055 acceptance criteria #3.
+    DB_GUARDRAIL_THRESHOLD: float = 0.75
     model_config = {"env_prefix": "", "case_sensitive": True, "env_file": ".env"}
 
     @property

--- a/app/main.py
+++ b/app/main.py
@@ -159,6 +159,36 @@ async def worker_health():
         },
     )
 
+
+@app.get("/health/concurrency")
+async def concurrency_health():
+    """Per-environment concurrency profile + live DB/broker saturation.
+
+    BE-W5-055: Worker concurrency settings are profiled and documented per
+    environment; DB pool and broker connections stay within safe limits;
+    guardrail alerts fire before saturation failures.
+    """
+    concurrency_guardrails_payload: dict = {}
+    try:
+        from app.services.concurrency_guardrails import guardrails_dict
+        from app.tasks.celery_app import celery_app as _celery_app
+        concurrency_guardrails_payload = guardrails_dict(_celery_app)
+    except Exception as exc:  # pragma: no cover - defensive
+        # Never let this endpoint 500 — degrade gracefully.
+        concurrency_guardrails_payload = {"error": str(exc)}
+
+    live = concurrency_guardrails_payload.get("live_metrics", {}) or {}
+    alerts_active = bool(live.get("alerts_active"))
+    from fastapi.responses import JSONResponse
+    return JSONResponse(
+        status_code=200,
+        content={
+            "status": "ok" if not alerts_active else "guardrail_alert",
+            "timestamp": datetime.utcnow().isoformat(),
+            **concurrency_guardrails_payload,
+        },
+    )
+
 @app.get("/health")
 def health_check():
     return {"status": "ok"}

--- a/app/services/concurrency_guardrails.py
+++ b/app/services/concurrency_guardrails.py
@@ -1,0 +1,225 @@
+"""BE-W5-055 — Async worker concurrency tuning profile & safeguards.
+
+Defines the per-environment concurrency profile (dev/staging/prod) and
+periodic guardrail checks that fire alerts **before** saturation failures
+cascades into API starvation or DB pool exhaustion.
+
+Public surface:
+  * ``EnvProfile``           — dataclass describing one environment.
+  * ``PROFILES``             — dict mapping env name -> EnvProfile.
+  * ``get_profile()``        — returns the active profile (fallback to dev).
+  * ``measure_broker_stress``— best-effort broker connection utilisation.
+  * ``evaluate_guardrails``  — single entry point that emits log alerts and
+                               updates MetricsRegistry gauges. Safe to call
+                               from anywhere (no broker round-trip when an
+                               explicit celery_app is passed in, otherwise
+                               prefers a lazy import to dodge a cycle).
+  * ``guardrails_dict``      — helper that turns the live readings into a
+                               dict suitable for the /health/concurrency
+                               endpoint.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional
+
+from app.core.config import settings
+from app.db.session import pool_health
+from app.services.metrics import set_gauge
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Per-environment profile                                                       #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class EnvProfile:
+    """Concurrency tuning knobs for a single environment.
+
+    These values are the documented *defaults*; operators may override any
+    individual field via the corresponding ``CELERY_WORKER_CONCURRENCY`` /
+    ``CELERY_MAX_TASKS_PER_CHILD`` / ``DB_POOL_SIZE`` settings.
+    """
+
+    concurrency: int
+    max_tasks: int
+    pool_size: int
+
+
+PROFILES: Dict[str, EnvProfile] = {
+    # Local dev: minimal footprint, low DB pool, low concurrency.
+    "dev": EnvProfile(concurrency=2, max_tasks=100, pool_size=5),
+    # Staging: roughly double dev, mirrors a small production node.
+    "staging": EnvProfile(concurrency=4, max_tasks=500, pool_size=10),
+    # Prod: tuned for a single worker node. Scale horizontally by adding
+    # nodes — this profile is intentionally conservative per node.
+    "prod": EnvProfile(concurrency=8, max_tasks=1000, pool_size=20),
+}
+
+
+def get_profile() -> EnvProfile:
+    """Return the active EnvProfile based on APP_ENV (falls back to dev)."""
+    env_key = (settings.APP_ENV or "dev").lower()
+    return PROFILES.get(env_key, PROFILES["dev"])
+
+
+# --------------------------------------------------------------------------- #
+# Saturation measurement                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def measure_broker_stress(celery_app: Any, timeout: float = 1.0) -> Dict[str, Any]:
+    """Estimate broker (Redis) connection utilisation.
+
+    Celery does not expose a direct connection count, so we use the count of
+    active workers (``inspect().active_queues()``) multiplied by the
+    effective worker concurrency as a best-effort proxy for simultaneous
+    broker connections. Returns ``estimated_connections``, ``max``,
+    ``saturation`` (fraction) and ``is_alert`` (boolean).
+
+    On any error we return a zero-utilisation payload so a failing probe
+    never blocks scheduling.
+    """
+    max_conns = max(int(settings.BROKER_MAX_CONNECTIONS), 1)
+    threshold = float(settings.BROKER_SATURATION_THRESHOLD)
+
+    if celery_app is None:
+        return {
+            "estimated_connections": 0,
+            "max": max_conns,
+            "saturation": 0.0,
+            "is_alert": False,
+        }
+
+    try:
+        inspect = celery_app.control.inspect(timeout=timeout)
+        active = inspect.active_queues() or {}
+        worker_count = len(active)
+    except Exception as exc:  # broker unreachable, timeout, etc.
+        logger.debug("BE-W5-055: broker probe failed (%s) — assuming zero load", exc)
+        return {
+            "estimated_connections": 0,
+            "max": max_conns,
+            "saturation": 0.0,
+            "is_alert": False,
+        }
+
+    profile = get_profile()
+    effective_concurrency = (
+        settings.CELERY_WORKER_CONCURRENCY
+        if settings.CELERY_WORKER_CONCURRENCY is not None
+        else profile.concurrency
+    )
+    estimated = max(worker_count, 0) * max(effective_concurrency, 0)
+    saturation = round(estimated / max_conns, 4)
+    return {
+        "estimated_connections": estimated,
+        "max": max_conns,
+        "saturation": saturation,
+        "is_alert": saturation >= threshold,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Evaluation entry point                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def evaluate_guardrails(
+    celery_app: Any,
+    *,
+    log_alerts: bool = True,
+) -> Dict[str, Any]:
+    """Run the full DB + broker guardrail evaluation.
+
+    Updates MetricsRegistry gauges in every case so external scrapers can
+    alert independently. Emits a WARNING log line when either alert fires
+    so log-based alerting (CloudWatch/Loki/etc.) also picks them up — this
+    satisfies the "guardrail alerts fire before saturation failures"
+    acceptance criterion without coupling to a specific alerting backend.
+    """
+    try:
+        db_stats = pool_health.get_stats()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("BE-W5-055: pool_health.get_stats failed: %s", exc)
+        db_stats = {"saturation": 0.0}
+
+    broker_stats = measure_broker_stress(celery_app)
+
+    # The DB guardrail threshold is STRICTLY below the saturation threshold
+    # so the [GUARDRAIL ALERT] hits logs BEFORE PoolSaturationMiddleware
+    # starts serving 530/503 responses. min() shrinks with either knob;
+    # we also enforce a 0.05 headroom so a careless setting can't zero it.
+    _db_sat_reject = float(settings.DB_POOL_SATURATION_THRESHOLD)
+    _db_guard = float(settings.DB_GUARDRAIL_THRESHOLD)
+    guardrail_threshold = float(min(_db_guard, max(_db_sat_reject - 0.05, 0.05)))
+    db_alert = float(db_stats.get("saturation", 0.0)) >= guardrail_threshold
+    broker_alert = bool(broker_stats.get("is_alert", False))
+
+    # Telemetry (always — even when no alert). Gauges are cheap (in-process
+    # dict) and let /metrics endpoints expose them directly.
+    set_gauge("db_pool.saturation", float(db_stats.get("saturation", 0.0)))
+    set_gauge("broker.saturation", float(broker_stats.get("saturation", 0.0)))
+    set_gauge("guardrail.alert.db", 1.0 if db_alert else 0.0)
+    set_gauge("guardrail.alert.broker", 1.0 if broker_alert else 0.0)
+
+    if log_alerts:
+        if db_alert:
+            logger.warning(
+                "[GUARDRAIL ALERT] DB pool near saturation: %s (guardrail_threshold=%s saturation_reject_threshold=%s)",
+                db_stats, guardrail_threshold, _db_sat_reject,
+            )
+        if broker_alert:
+            logger.warning(
+                "[GUARDRAIL ALERT] Broker connection saturation: %s (threshold=%s)",
+                broker_stats, settings.BROKER_SATURATION_THRESHOLD,
+            )
+
+    return {
+        "db": db_stats,
+        "broker": broker_stats,
+        "alerts_active": bool(db_alert or broker_alert),
+        "thresholds": {
+            "db_guardrail": guardrail_threshold,
+            "db_saturation_reject": _db_sat_reject,
+            "broker_guardrail": float(settings.BROKER_SATURATION_THRESHOLD),
+        },
+    }
+
+
+def guardrails_dict(celery_app: Optional[Any] = None) -> Dict[str, Any]:
+    """Render the current profile + live gauge readings for /health.
+
+    Returning a pure dict keeps the route handler trivial and makes the
+    payload easy to assert in tests.
+    """
+    profile = get_profile()
+    live = evaluate_guardrails(celery_app, log_alerts=False)
+    effective_concurrency = (
+        settings.CELERY_WORKER_CONCURRENCY
+        if settings.CELERY_WORKER_CONCURRENCY is not None
+        else profile.concurrency
+    )
+    effective_max_tasks = (
+        settings.CELERY_MAX_TASKS_PER_CHILD
+        if settings.CELERY_MAX_TASKS_PER_CHILD is not None
+        else profile.max_tasks
+    )
+    return {
+        "env": (settings.APP_ENV or "dev").lower(),
+        "profile": {
+            "concurrency": effective_concurrency,
+            "max_tasks_per_child": effective_max_tasks,
+            "pool_size": settings.DB_POOL_SIZE or profile.pool_size,
+        },
+        "profile_defaults": asdict(profile),
+        "overrides_in_effect": {
+            "concurrency_override": settings.CELERY_WORKER_CONCURRENCY is not None,
+            "max_tasks_override": settings.CELERY_MAX_TASKS_PER_CHILD is not None,
+        },
+        "live_metrics": live,
+    }

--- a/app/tasks/celery_app.py
+++ b/app/tasks/celery_app.py
@@ -49,6 +49,14 @@ celery_app.conf.update(
             "task": "app.tasks.idempotency_tasks.cleanup_expired_idempotency_keys",
             "schedule": 3600.0,  # every hour
         },
+        # BE-W5-055: periodic DB pool + broker connection guardrail check.
+        # Runs every 60s alongside the existing beats; emits a WARNING log
+        # line and flips ``guardrail.alert.*`` gauges when saturation
+        # thresholds are crossed.
+        "concurrency-guardrail-check": {
+            "task": "app.tasks.celery_app.guardrail_check_task",
+            "schedule": 60.0,
+        },
     },
 )
 
@@ -178,3 +186,17 @@ def _on_worker_ready(sender=None, **kwargs) -> None:  # noqa: ANN001
         logger.critical("BE-W5-051: worker bootstrap aborted — %s", exc)
         # Fail fast so the orchestrator sees the worker crash and intervenes.
         sys.exit(1)
+
+
+@celery_app.task(name="app.tasks.celery_app.guardrail_check_task")
+def guardrail_check_task() -> Dict[str, object]:
+    """Periodic DB + broker saturation guardrail evaluation.
+
+    BE-W5-055: returns the live readings; emits WARNING log lines and sets
+    ``guardrail.alert.*`` gauges via ``evaluate_guardrails``. Runs from a
+    beat schedule every 60 s.
+    """
+    # Local import avoids a circular dep at module-import time
+    # (concurrency_guardrails imports ... → celery_app imports).
+    from app.services.concurrency_guardrails import evaluate_guardrails
+    return evaluate_guardrails(celery_app)

--- a/docs/WAVE_5_CONTEXT.md
+++ b/docs/WAVE_5_CONTEXT.md
@@ -11,3 +11,57 @@ $$\text{Reliability Index} = (\text{SLO} \times 0.40) + (\text{Tests} \times 0.3
 A release candidate will receive an automatic **NO-GO** status if:
 1. The combined `Reliability Index` drops lower than **85.0**.
 2. Any unmitigated, open security vulnerability regressions exist inside core dependencies or containers.
+
+## Worker Concurrency & Saturation Profiles (BE-W5-055)
+
+Per-environment defaults selected by `APP_ENV` (case-insensitive;
+unknown values fall back to `dev`). Any individual field may be overridden
+by the corresponding `CELERY_WORKER_CONCURRENCY`, `CELERY_MAX_TASKS_PER_CHILD`,
+or `DB_POOL_SIZE` setting without touching the table below.
+
+| Environment | Worker Concurrency | Max Tasks / Child | DB Pool Size | Broker Max Connections | Threshold (broker) |
+|-------------|--------------------|-------------------|--------------|------------------------|--------------------|
+| `dev`       | 2                  | 100               | 5            | 100                    | 0.80               |
+| `staging`   | 4                  | 500               | 10           | 100                    | 0.80               |
+| `prod`      | 8                  | 1000              | 20           | 100                    | 0.80               |
+
+### Saturation Guardrails
+
+Two saturation channels are evaluated every 60 s by the
+`app.tasks.celery_app.guardrail_check_task` beat job (see
+`app/services/concurrency_guardrails.py`).
+
+* **DB pool** — alert fires when `pool_saturation >= DB_GUARDRAIL_THRESHOLD`
+  (default `0.75`). This threshold is **strictly below** the saturation
+  threshold that `PoolSaturationMiddleware` uses to start rejecting (530/503)
+  — i.e. `DB_POOL_SATURATION_THRESHOLD` (default `0.9`). The guardrail takes
+  the lower of the two with a 0.05 headroom, so an operator tightening the
+  rejection threshold below `0.8` will not silently neuter the alert.
+* **Broker (Redis)** — alerts when
+  `worker_count * concurrency >= BROKER_SATURATION_THRESHOLD *
+  BROKER_MAX_CONNECTIONS`. The worker-count proxy comes from
+  `celery_app.control.inspect().active_queues()`.
+
+When an alert fires:
+1. A `WARNING` log line is emitted with `[GUARDRAIL ALERT]` prefix that
+   prints both the guardrail threshold and the saturation-reject threshold
+   so operators can see the headroom in the same line.
+2. `MetricsRegistry` sets `guardrail.alert.db=1.0` /
+   `guardrail.alert.broker=1.0` and updates the `db_pool.saturation` and
+   `broker.saturation` gauges.
+
+A live readout is exposed via `GET /health/concurrency`, which returns
+the active profile, any operator-applied overrides, and the most recent
+guardrail readings so orchestrators can use it as a readiness gate.
+
+### Tuning Workflow
+
+1. Pick an environment in `APP_ENV`.
+2. If a single field needs adjustment (e.g. larger DB pool in a tuned
+   staging node), set the individual env var — do **not** fork the
+   profile.
+3. Watch `/health/concurrency` after each change; if alert gauges stay
+   at `0.0` for a representative load window, the change is healthy.
+4. If `db_pool.saturation` or `broker.saturation` consistently sits above
+   the threshold, scale horizontally (add worker nodes) **before**
+   raising any per-node number.

--- a/tests/test_be_w5_055_concurrency_guardrails.py
+++ b/tests/test_be_w5_055_concurrency_guardrails.py
@@ -1,0 +1,202 @@
+"""Tests for BE-W5-055 — Async worker concurrency tuning profile & safeguards.
+
+Covers:
+  * Per-environment profile selection + fallback.
+  * Broker stress proxy saturation logic (with mocked celery_app).
+  * Guardrail evaluation emits the right gauges + log alerts.
+  * Concurrency health endpoint reflects the live state.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services import concurrency_guardrails as cg
+from app.services.metrics import metrics
+
+
+# --------------------------------------------------------------------------- #
+# Profile selection                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_get_profile_known_env_returns_named_profile():
+    with patch.object(cg.settings, "APP_ENV", "prod"):
+        profile = cg.get_profile()
+    assert profile.concurrency == 8
+    assert profile.max_tasks == 1000
+    assert profile.pool_size == 20
+
+
+def test_get_profile_unknown_env_falls_back_to_dev():
+    with patch.object(cg.settings, "APP_ENV", "qa-mystery"):
+        profile = cg.get_profile()
+    assert profile == cg.PROFILES["dev"]
+
+
+def test_get_profile_environment_is_case_insensitive():
+    with patch.object(cg.settings, "APP_ENV", "Staging"):
+        profile = cg.get_profile()
+    assert profile == cg.PROFILES["staging"]
+
+
+# --------------------------------------------------------------------------- #
+# Broker stress proxy                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_broker_stress_with_no_celery_app_returns_zero():
+    payload = cg.measure_broker_stress(None)
+    assert payload == {
+        "estimated_connections": 0,
+        "max": cg.settings.BROKER_MAX_CONNECTIONS,
+        "saturation": 0.0,
+        "is_alert": False,
+    }
+
+
+def test_broker_stress_when_no_workers_observed():
+    fake_app = MagicMock()
+    fake_app.control.inspect.return_value.active_queues.return_value = {}
+    payload = cg.measure_broker_stress(fake_app)
+    assert payload["estimated_connections"] == 0
+    assert payload["is_alert"] is False
+
+
+def test_broker_stress_when_workers_present_under_threshold():
+    fake_app = MagicMock()
+    fake_app.control.inspect.return_value.active_queues.return_value = {
+        f"w{i}": [{"name": "celery"}] for i in range(2)  # 2 workers
+    }
+    with patch.object(cg.settings, "CELERY_WORKER_CONCURRENCY", 4), \
+         patch.object(cg.settings, "BROKER_MAX_CONNECTIONS", 100):
+        payload = cg.measure_broker_stress(fake_app)
+    # 2 workers * 4 → 8 estimated connections; saturation = 0.08
+    assert payload["estimated_connections"] == 8
+    assert payload["saturation"] == pytest.approx(0.08, abs=1e-4)
+    assert payload["is_alert"] is False
+
+
+def test_broker_stress_when_alert_threshold_exceeded():
+    fake_app = MagicMock()
+    fake_app.control.inspect.return_value.active_queues.return_value = {
+        f"w{i}": [{"name": "celery"}] for i in range(10)  # 10 workers
+    }
+    with patch.object(cg.settings, "CELERY_WORKER_CONCURRENCY", 8), \
+         patch.object(cg.settings, "BROKER_MAX_CONNECTIONS", 50), \
+         patch.object(cg.settings, "BROKER_SATURATION_THRESHOLD", 0.8):
+        payload = cg.measure_broker_stress(fake_app)
+    # 10 workers * 8 = 80 > 0.8 * 50 = 40  → alert
+    assert payload["estimated_connections"] == 80
+    assert payload["is_alert"] is True
+    assert payload["saturation"] >= 0.8
+
+
+def test_broker_stress_swallows_broker_errors_gracefully():
+    fake_app = MagicMock()
+    fake_app.control.inspect.side_effect = RuntimeError("broker down")
+    payload = cg.measure_broker_stress(fake_app)
+    assert payload == {
+        "estimated_connections": 0,
+        "max": cg.settings.BROKER_MAX_CONNECTIONS,
+        "saturation": 0.0,
+        "is_alert": False,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Guardrail evaluation                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_evaluate_guardrails_no_alert_clears_gauges():
+    metrics._gauges.clear()  # type: ignore[attr-defined]
+    fake_app = MagicMock()
+    fake_app.control.inspect.return_value.active_queues.return_value = {
+        "w1": [{"name": "celery"}],
+    }
+    with patch.object(cg.pool_health, "get_stats", return_value={
+        "pool_size": 10, "active": 1, "idle": 9, "overflow": 0,
+        "max_overflow": 20, "saturation": 0.1,
+    }), patch.object(cg.settings, "CELERY_WORKER_CONCURRENCY", 2), \
+         patch.object(cg.settings, "DB_GUARDRAIL_THRESHOLD", 0.75), \
+         patch.object(cg.settings, "DB_POOL_SATURATION_THRESHOLD", 0.9):
+        result = cg.evaluate_guardrails(fake_app, log_alerts=False)
+    assert result["alerts_active"] is False
+    assert metrics._gauges["guardrail.alert.db"] == 0.0  # type: ignore[attr-defined]
+    assert metrics._gauges["guardrail.alert.broker"] == 0.0  # type: ignore[attr-defined]
+
+
+def test_evaluate_guardrails_alerts_above_guardrail_but_below_saturation():
+    """Guardrail must fire *before* PoolSaturationMiddleware's reject threshold.
+
+    saturation 0.8 sits between DB_GUARDRAIL_THRESHOLD (0.75) and
+    DB_POOL_SATURATION_THRESHOLD (0.9) — guardrail fires, 530s do not.
+    """
+    metrics._gauges.clear()  # type: ignore[attr-defined]
+    fake_app = MagicMock()
+    fake_app.control.inspect.return_value.active_queues.return_value = {}
+    with patch.object(cg.pool_health, "get_stats", return_value={
+        "pool_size": 10, "active": 8, "idle": 2, "overflow": 0,
+        "max_overflow": 20, "saturation": 0.8,
+    }), patch.object(cg.settings, "DB_GUARDRAIL_THRESHOLD", 0.75), \
+         patch.object(cg.settings, "DB_POOL_SATURATION_THRESHOLD", 0.9):
+        result = cg.evaluate_guardrails(fake_app, log_alerts=False)
+    assert result["alerts_active"] is True
+    assert result["thresholds"]["db_guardrail"] == pytest.approx(0.75, abs=1e-6)
+    assert result["thresholds"]["db_saturation_reject"] == pytest.approx(0.9, abs=1e-6)
+    assert metrics._gauges["guardrail.alert.db"] == 1.0  # type: ignore[attr-defined]
+
+
+def test_evaluate_guardrails_emits_log_warning_on_db_alert(caplog):
+    metrics._gauges.clear()  # type: ignore[attr-defined]
+    fake_app = MagicMock()
+    fake_app.control.inspect.return_value.active_queues.return_value = {}
+    with patch.object(cg.pool_health, "get_stats", return_value={
+        "pool_size": 10, "active": 9, "idle": 1, "overflow": 0,
+        "max_overflow": 20, "saturation": 0.95,
+    }), patch.object(cg.settings, "DB_POOL_SATURATION_THRESHOLD", 0.9), \
+         patch.object(cg.settings, "DB_GUARDRAIL_THRESHOLD", 0.75):
+        with caplog.at_level(logging.WARNING, logger=cg.logger.name):
+            result = cg.evaluate_guardrails(fake_app)
+    assert result["alerts_active"] is True
+    assert metrics._gauges["guardrail.alert.db"] == 1.0  # type: ignore[attr-defined]
+    assert any(
+        "[GUARDRAIL ALERT]" in rec.message and "DB pool" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_guardrails_dict_overlay_round_trip():
+    fake_app = MagicMock()
+    fake_app.control.inspect.return_value.active_queues.return_value = {
+        "w1": [{"name": "celery"}],
+    }
+    with patch.object(cg.settings, "APP_ENV", "staging"), \
+         patch.object(cg.settings, "CELERY_WORKER_CONCURRENCY", None), \
+         patch.object(cg.pool_health, "get_stats", return_value={
+             "pool_size": 10, "active": 0, "idle": 10, "overflow": 0,
+             "max_overflow": 20, "saturation": 0.0,
+         }), patch.object(cg.settings, "DB_GUARDRAIL_THRESHOLD", 0.75), \
+         patch.object(cg.settings, "DB_POOL_SATURATION_THRESHOLD", 0.9):
+        payload = cg.guardrails_dict(fake_app)
+    assert payload["env"] == "staging"
+    assert payload["profile"]["concurrency"] == 4  # staging default
+    assert payload["overrides_in_effect"]["concurrency_override"] is False
+    assert payload["live_metrics"]["alerts_active"] is False
+
+
+def test_guardrails_dict_reflects_concurrency_override():
+    with patch.object(cg.settings, "APP_ENV", "prod"), \
+         patch.object(cg.settings, "CELERY_WORKER_CONCURRENCY", 16), \
+         patch.object(cg.pool_health, "get_stats", return_value={
+             "pool_size": 20, "active": 0, "idle": 20, "overflow": 0,
+             "max_overflow": 40, "saturation": 0.0,
+         }), patch.object(cg.settings, "DB_GUARDRAIL_THRESHOLD", 0.75), \
+         patch.object(cg.settings, "DB_POOL_SATURATION_THRESHOLD", 0.9):
+        payload = cg.guardrails_dict(None)
+    assert payload["profile"]["concurrency"] == 16
+    assert payload["overrides_in_effect"]["concurrency_override"] is True
+    assert payload["profile_defaults"]["concurrency"] == 8  # prod baseline preserved


### PR DESCRIPTION
Resolves #316 in a single PR.

## Summary

Worker concurrency is now profiled per environment, with a periodic guardrail
that fires alerts **before** the existing saturation-reject threshold.

### New module: app/services/concurrency_guardrails.py
- `EnvProfile` dataclass + `PROFILES` dict (dev/staging/prod).
- `get_profile()` picks the active profile via `APP_ENV` (case-insensitive,
  falls back to dev).
- `measure_broker_stress(celery_app)` estimates Redis connection utilisation
  from `control.inspect().active_queues()` worker count × effective
  concurrency (no direct connection count is exposed by Celery).
- `evaluate_guardrails(celery_app)` is the single entry point: it consults
  the existing `PoolHealthChecker`, calls `measure_broker_stress`, emits
  `[GUARDRAIL ALERT]` WARNING log lines, and flips four
  `MetricsRegistry` gauges (`db_pool.saturation`, `broker.saturation`,
  `guardrail.alert.db`, `guardrail.alert.broker`) so external scrapers can
  alert independently. Returns a `thresholds` dict so callers can see the
  headroom between the guardrail and the saturation-reject thresholds.
- `guardrails_dict(celery_app)` is the dict used by the new endpoint.

### Threshold design (BE-W5-055 acceptance criterion #3)
The DB guardrail uses `min(DB_GUARDRAIL_THRESHOLD,
DB_POOL_SATURATION_THRESHOLD - 0.05)` so it always stays strictly below
the rejection threshold that `PoolSaturationMiddleware` uses to start
serving 530/503. The default `DB_GUARDRAIL_THRESHOLD=0.75` gives 0.15 of
headroom against the default `DB_POOL_SATURATION_THRESHOLD=0.9` — the
alert fires in logs **before** the API starts rejecting.

### Config additions (app/core/config.py)
- `APP_ENV` (default `dev`)
- `CELERY_WORKER_CONCURRENCY` (optional override)
- `CELERY_MAX_TASKS_PER_CHILD` (optional override)
- `BROKER_MAX_CONNECTIONS` (default 100)
- `BROKER_SATURATION_THRESHOLD` (default 0.8)
- `DB_GUARDRAIL_THRESHOLD` (default 0.75)

### Celery wiring (app/tasks/celery_app.py)
- New beat entry `concurrency-guardrail-check` runs every 60 s.
- New `guardrail_check_task` Celery task calls `evaluate_guardrails`. The
  module-level import is kept lazy inside the task body to avoid the
  circular dep on `concurrency_guardrails → celery_app`.
- Does not regress the previous PRs `verify_queue_bindings()` /
  `worker_ready` fail-fast hook.

### API surface (app/main.py)
- New `GET /health/concurrency` returns the active profile, any
  operator-applied overrides, the live gauge readings, and the threshold
  headroom — useful as an orchestration readiness gate. The endpoint is
  defensive: any broker probe failure degrades to `{"error": ...}` so it
  never 500s.

### Docs (docs/WAVE_5_CONTEXT.md)
- New "Worker Concurrency & Saturation Profiles (BE-W5-055)" section
  with the table of per-env defaults, the strict-below guardrail design,
  the alert-emission contract, and a tuning workflow.

### Tests
- tests/test_be_w5_055_concurrency_guardrails.py covers profile
  selection/fallback/case-insensitivity, broker-down, no-alert clearing,
  alert-above-guardrail-below-saturation (the new boundary case),
  log-warning emission, and override round-trip.

## Behaviour vs. existing infra
- PoolHealthChecker + PoolSaturationMiddleware are reused as-is. This PR
  only adds the explicit before-saturation alert channel; the 530/503
  reject path is unchanged.

## Risk & Compatibility
- Additive: new module, new config, new endpoint, new beat entry, new
  tests. No breaking changes to existing settings or routes.

Closes #316