### PR TITLE
feat: resolve all Mercy60-assigned issues (#308, #309, #311, #313)

### DIFF
--- a/alembic/versions/0024_mercy60_job_enhancements.py
+++ b/alembic/versions/0024_mercy60_job_enhancements.py
@@ -1,0 +1,156 @@
+"""BE-W5-047/048/050/052: Job enhancements for Mercy60 issues.
+
+Revision ID: 0024_mercy60_job_enhancements
+Revises: 0023_job_quarantine_and_dr_replay
+Create Date: 2026-07-29
+
+Adds:
+  - BE-W5-050: ``error_code``, ``error_retryable``, ``error_details`` columns
+  - BE-W5-048: ``retry_class``, ``dead_letter_reason``, ``dead_letter_at`` columns
+  - BE-W5-047: ``worker_id``, ``heartbeat_at``, ``lease_expires_at`` columns
+  - BE-W5-052: ``under_investigation``, ``under_dispute``, ``audit_critical`` columns
+  - Extends ``jobstatus`` enum with ``dead_letter`` value
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0024_mercy60_job_enhancements"
+down_revision = "0023_job_quarantine_and_dr_replay"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # BE-W5-050: Typed error metadata
+    op.add_column(
+        "jobs",
+        sa.Column("error_code", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column("error_retryable", sa.Boolean(), nullable=True),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column("error_details", sa.JSON(), nullable=True),
+    )
+    op.create_index(
+        "idx_jobs_error_code",
+        "jobs",
+        ["error_code"],
+        unique=False,
+    )
+
+    # BE-W5-048: Retry taxonomy and dead-letter
+    op.add_column(
+        "jobs",
+        sa.Column("retry_class", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column("dead_letter_reason", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column("dead_letter_at", sa.DateTime(), nullable=True),
+    )
+
+    # Extend jobstatus enum with DEAD_LETTER
+    op.execute(
+        "ALTER TYPE jobstatus ADD VALUE IF NOT EXISTS 'dead_letter'"
+    )
+
+    # BE-W5-047: Lease heartbeat
+    op.add_column(
+        "jobs",
+        sa.Column("worker_id", sa.String(length=128), nullable=True),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column("heartbeat_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column("lease_expires_at", sa.DateTime(), nullable=True),
+    )
+    op.create_index(
+        "idx_jobs_worker_id",
+        "jobs",
+        ["worker_id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_jobs_lease_expires_at",
+        "jobs",
+        ["lease_expires_at"],
+        unique=False,
+    )
+
+    # BE-W5-052: Retention tier protection flags
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "under_investigation",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "under_dispute",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "audit_critical",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.create_index(
+        "idx_jobs_under_investigation",
+        "jobs",
+        ["under_investigation"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_jobs_under_dispute",
+        "jobs",
+        ["under_dispute"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    # BE-W5-052
+    op.drop_index("idx_jobs_under_dispute", table_name="jobs")
+    op.drop_index("idx_jobs_under_investigation", table_name="jobs")
+    op.drop_column("jobs", "audit_critical")
+    op.drop_column("jobs", "under_dispute")
+    op.drop_column("jobs", "under_investigation")
+
+    # BE-W5-047
+    op.drop_index("idx_jobs_lease_expires_at", table_name="jobs")
+    op.drop_index("idx_jobs_worker_id", table_name="jobs")
+    op.drop_column("jobs", "lease_expires_at")
+    op.drop_column("jobs", "heartbeat_at")
+    op.drop_column("jobs", "worker_id")
+
+    # BE-W5-048 (enum value not removable)
+    op.drop_column("jobs", "dead_letter_at")
+    op.drop_column("jobs", "dead_letter_reason")
+    op.drop_column("jobs", "retry_class")
+
+    # BE-W5-050
+    op.drop_index("idx_jobs_error_code", table_name="jobs")
+    op.drop_column("jobs", "error_details")
+    op.drop_column("jobs", "error_retryable")
+    op.drop_column("jobs", "error_code")

--- a/app/api/v1/endpoints/jobs.py
+++ b/app/api/v1/endpoints/jobs.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from celery.result import AsyncResult
@@ -11,8 +11,21 @@ from sqlalchemy.orm import Session
 from fastapi import Request
 
 from app.db.session import get_db
-from app.models.job import Job, JobStatus, JobType
+from app.models.job import (
+    Job,
+    JobErrorDetail,
+    JobResultEnvelope,
+    JobStatus,
+    JobType,
+    RetryClass,
+)
 from app.services.audit_log import audit_log
+from app.services.job_cleanup import (
+    JobCleanupService,
+    get_retry_policy,
+    heartbeat_job,
+    reclaim_stale_leases,
+)
 from app.services.metrics import increment_counter, timer
 from app.tasks.celery_app import celery_app
 from app.tasks.sla_tasks import enqueue_sla_computation, enqueue_bulk_sla_computation
@@ -20,7 +33,7 @@ from app.tasks.webhook_tasks import dispatch_webhook_delivery
 from app.utils.correlation import get_correlation_id
 from app.utils.logging import get_structured_logger
 from app.core.security import require_engineer, require_admin
-from app.services.job_cleanup import JobCleanupService
+from app.core.config import settings as cfg
 
 logger = get_structured_logger("jobs_api")
 
@@ -53,9 +66,12 @@ class JobResponse(BaseModel):
     payload: Optional[dict] = None
     result: Optional[dict] = None
     error: Optional[str] = None
+    # BE-W5-050: Typed error detail
+    error_detail: Optional[JobErrorDetail] = None
     # BE-041: Retry metadata
     retry_count: int = 0
     max_retries: int = 3
+    retry_class: Optional[str] = None
     last_retried_at: Optional[str] = None
     started_at: Optional[str] = None
     finished_at: Optional[str] = None
@@ -64,39 +80,141 @@ class JobResponse(BaseModel):
     payload_hash: Optional[str] = None
     quarantine_reason: Optional[str] = None
     quarantined_at: Optional[str] = None
+    # BE-W5-048: Dead-letter metadata
+    dead_letter_reason: Optional[str] = None
+    dead_letter_at: Optional[str] = None
+    # BE-W5-047: Lease heartbeat
+    worker_id: Optional[str] = None
+    heartbeat_at: Optional[str] = None
+    lease_expires_at: Optional[str] = None
+    # BE-W5-052: Protection flags
+    under_investigation: bool = False
+    under_dispute: bool = False
+    audit_critical: bool = False
 
     model_config = {"from_attributes": True}
 
 
-# BE-042: Job cleanup schemas
+# BE-W5-050: Standardised result envelope response
+class JobEnvelopeResponse(BaseModel):
+    """Standardised envelope wrapping every job endpoint response."""
+    job_id: str
+    celery_task_id: str
+    job_type: str
+    status: str
+    progress: float = 0.0
+    result: Optional[Dict[str, Any]] = None
+    error: Optional[JobErrorDetail] = None
+    retry_count: int = 0
+    max_retries: int = 3
+    retry_class: Optional[str] = None
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    created_at: Optional[str] = None
+    # Extended metadata
+    worker_id: Optional[str] = None
+    lease_expires_at: Optional[str] = None
+    under_investigation: bool = False
+    under_dispute: bool = False
+    audit_critical: bool = False
+
+    model_config = {"from_attributes": True}
+
+
+# BE-042: Job cleanup schemas (extended for BE-W5-052)
 class JobRetentionStatsResponse(BaseModel):
     """Current job retention statistics."""
     total_jobs: int
     by_status: dict
     by_age: dict
+    protected: Optional[dict] = None
 
 
 class JobCleanupRequest(BaseModel):
     """Request parameters for job cleanup."""
-    successful_retention_days: Optional[int] = None
-    failed_retention_days: Optional[int] = None
+    retention_days: Optional[Dict[str, int]] = None  # BE-W5-052: per-status windows
     dry_run: bool = False
+    batch_size: int = 1000
 
 
 class JobCleanupResponse(BaseModel):
     """Response from job cleanup operation."""
-    successful_jobs_deleted: int
-    failed_jobs_deleted: int
-    revoked_jobs_deleted: int
     total_deleted: int
-    cutoff_successful: str
-    cutoff_failed: str
+    deleted_by_status: dict
+    cutoffs: dict
     dry_run: bool
+
+
+# BE-W5-047: Lease reclamation
+class LeaseReclamationRequest(BaseModel):
+    timeout_seconds: int = 120
+    batch_size: int = 50
+    dry_run: bool = False
+
+
+class LeaseReclamationResponse(BaseModel):
+    stale_leases_found: int
+    reclaimed: int
+    dry_run: bool
+    checked_at: str
+
+
+# BE-W5-052: Audit-critical cleanup
+class AuditCriticalCleanupResponse(BaseModel):
+    audit_critical_eligible: int
+    audit_critical_deleted: int
+    dry_run: bool
+    cutoff: str
+    retention_days: int
+
+
+# BE-W5-052: Protection flag management
+class ProtectionFlagRequest(BaseModel):
+    under_investigation: Optional[bool] = None
+    under_dispute: Optional[bool] = None
+
+
+# BE-W5-048: Retry taxonomy response
+class RetryPolicyResponse(BaseModel):
+    job_type: str
+    retry_class: str
+    max_retries: int
+    base_delay_seconds: int
+
+
+class DeadLetterSummary(BaseModel):
+    id: UUID
+    celery_task_id: str
+    job_type: JobType
+    dead_letter_reason: Optional[str] = None
+    dead_letter_at: Optional[str] = None
+    retry_count: int
+    max_retries: int
+    created_at: str
 
 
 # --------------------------------------------------------------------------- #
 # Helpers                                                                      #
 # --------------------------------------------------------------------------- #
+
+
+def _build_error_detail(job: Job) -> Optional[JobErrorDetail]:
+    """Build a typed error detail from a Job record for BE-W5-050."""
+    if job.error_code:
+        return JobErrorDetail(
+            code=job.error_code,
+            message=job.error or "",
+            retryable=job.error_retryable if job.error_retryable is not None else False,
+            details=job.error_details,
+        )
+    if job.error:
+        return JobErrorDetail(
+            code="UNKNOWN",
+            message=job.error,
+            retryable=False,
+        )
+    return None
+
 
 def _serialize_job(job: Job) -> JobResponse:
     def _parse(val):
@@ -119,17 +237,49 @@ def _serialize_job(job: Job) -> JobResponse:
         payload=_parse(job.payload),
         result=_parse(job.result),
         error=job.error,
-        # BE-041: Include retry metadata
+        error_detail=_build_error_detail(job),
         retry_count=job.retry_count,
         max_retries=job.max_retries,
+        retry_class=job.retry_class,
         last_retried_at=job.last_retried_at.isoformat() if job.last_retried_at else None,
         started_at=job.started_at.isoformat() if job.started_at else None,
         finished_at=job.finished_at.isoformat() if job.finished_at else None,
         created_at=job.created_at.isoformat(),
-        # BE-W5-054: Include quarantine metadata
         payload_hash=job.payload_hash,
         quarantine_reason=job.quarantine_reason,
         quarantined_at=job.quarantined_at.isoformat() if job.quarantined_at else None,
+        dead_letter_reason=job.dead_letter_reason,
+        dead_letter_at=job.dead_letter_at.isoformat() if job.dead_letter_at else None,
+        worker_id=job.worker_id,
+        heartbeat_at=job.heartbeat_at.isoformat() if job.heartbeat_at else None,
+        lease_expires_at=job.lease_expires_at.isoformat() if job.lease_expires_at else None,
+        under_investigation=job.under_investigation or False,
+        under_dispute=job.under_dispute or False,
+        audit_critical=job.audit_critical or False,
+    )
+
+
+def _serialize_envelope(job: Job) -> JobEnvelopeResponse:
+    """BE-W5-050: Serialize a Job as the standardised result envelope."""
+    return JobEnvelopeResponse(
+        job_id=str(job.id),
+        celery_task_id=job.celery_task_id,
+        job_type=job.job_type.value,
+        status=job.status.value,
+        progress=job.progress or 0.0,
+        result=json.loads(job.result) if job.result else None,
+        error=_build_error_detail(job),
+        retry_count=job.retry_count or 0,
+        max_retries=job.max_retries or 3,
+        retry_class=job.retry_class,
+        started_at=job.started_at.isoformat() if job.started_at else None,
+        finished_at=job.finished_at.isoformat() if job.finished_at else None,
+        created_at=job.created_at.isoformat(),
+        worker_id=job.worker_id,
+        lease_expires_at=job.lease_expires_at.isoformat() if job.lease_expires_at else None,
+        under_investigation=job.under_investigation or False,
+        under_dispute=job.under_dispute or False,
+        audit_critical=job.audit_critical or False,
     )
 
 
@@ -141,15 +291,13 @@ def _get_job_or_404(db: Session, job_id: UUID) -> Job:
 
 
 def _sync_job_status_from_celery(db: Session, job: Job) -> Job:
-    """
-    Pull the latest status from Celery backend and update the DB record
-    for jobs that haven't reached a terminal state yet.
-    """
-    if job.status in (JobStatus.SUCCESS, JobStatus.FAILURE, JobStatus.REVOKED):
+    """Pull latest status from Celery backend for in-progress jobs."""
+    if job.status in (JobStatus.SUCCESS, JobStatus.FAILURE, JobStatus.REVOKED,
+                       JobStatus.DEAD_LETTER, JobStatus.QUARANTINED):
         return job
 
     task_result: AsyncResult = AsyncResult(job.celery_task_id, app=celery_app)
-    celery_state = task_result.state  # PENDING, STARTED, SUCCESS, FAILURE, REVOKED
+    celery_state = task_result.state
 
     state_map = {
         "PENDING": JobStatus.PENDING,
@@ -177,36 +325,43 @@ def _sync_job_status_from_celery(db: Session, job: Job) -> Job:
     response_model=JobResponse,
     status_code=status.HTTP_202_ACCEPTED,
 )
-def submit_sla_computation(payload: SLAJobRequest, request: Request, current_user=Depends(require_engineer), db: Session = Depends(get_db)):
-    """
-    Enqueue an async SLA computation job for a single device.
-    Returns immediately with a job record for status polling.
-    """
+def submit_sla_computation(
+    payload: SLAJobRequest,
+    request: Request,
+    current_user=Depends(require_engineer),
+    db: Session = Depends(get_db),
+):
+    """Enqueue an async SLA computation job for a single device."""
     correlation_id = get_correlation_id()
-    
+
     logger.info(
         "Submitting SLA computation job",
         device_id=payload.device_id,
         period=payload.period,
-        correlation_id=correlation_id
+        correlation_id=correlation_id,
     )
-    
+
     with timer("job_submission_duration", {"job_type": "sla_computation"}):
         increment_counter("jobs_submitted", tags={"job_type": "sla_computation"})
         job = enqueue_sla_computation(
-            db, 
-            device_id=payload.device_id, 
+            db,
+            device_id=payload.device_id,
             period=payload.period,
-            correlation_id=correlation_id
+            correlation_id=correlation_id,
         )
-        
+
+        # BE-W5-048: Apply retry taxonomy defaults
+        policy = get_retry_policy(JobType.SLA_COMPUTATION.value)
+        job.retry_class = str(policy.get("retry_class", "exponential_backoff"))
+        db.commit()
+        db.refresh(job)
+
         logger.info(
             "SLA computation job submitted",
             job_id=str(job.id),
             celery_task_id=job.celery_task_id,
-            correlation_id=correlation_id
+            correlation_id=correlation_id,
         )
-        
         return _serialize_job(job)
 
 
@@ -215,44 +370,50 @@ def submit_sla_computation(payload: SLAJobRequest, request: Request, current_use
     response_model=JobResponse,
     status_code=status.HTTP_202_ACCEPTED,
 )
-def submit_bulk_sla_computation(payload: BulkSLAJobRequest, request: Request, current_user=Depends(require_engineer), db: Session = Depends(get_db)):
-    """
-    Enqueue an async bulk SLA computation job for multiple devices.
-    Returns immediately with a job record for status polling.
-    """
+def submit_bulk_sla_computation(
+    payload: BulkSLAJobRequest,
+    request: Request,
+    current_user=Depends(require_engineer),
+    db: Session = Depends(get_db),
+):
+    """Enqueue an async bulk SLA computation job for multiple devices."""
     correlation_id = get_correlation_id()
-    
+
     if not payload.device_ids:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="device_ids must not be empty.",
         )
-    
+
     logger.info(
         "Submitting bulk SLA computation job",
         device_count=len(payload.device_ids),
         period=payload.period,
-        correlation_id=correlation_id
+        correlation_id=correlation_id,
     )
-    
+
     with timer("job_submission_duration", {"job_type": "bulk_sla_computation"}):
         increment_counter("jobs_submitted", tags={"job_type": "bulk_sla_computation"})
         increment_counter("bulk_job_devices_submitted", value=len(payload.device_ids))
         job = enqueue_bulk_sla_computation(
-            db, 
-            device_ids=payload.device_ids, 
+            db,
+            device_ids=payload.device_ids,
             period=payload.period,
-            correlation_id=correlation_id
+            correlation_id=correlation_id,
         )
-        
+
+        policy = get_retry_policy(JobType.BULK_SLA_COMPUTATION.value)
+        job.retry_class = str(policy.get("retry_class", "exponential_backoff"))
+        db.commit()
+        db.refresh(job)
+
         logger.info(
             "Bulk SLA computation job submitted",
             job_id=str(job.id),
             celery_task_id=job.celery_task_id,
             device_count=len(payload.device_ids),
-            correlation_id=correlation_id
+            correlation_id=correlation_id,
         )
-        
         return _serialize_job(job)
 
 
@@ -274,14 +435,28 @@ def list_jobs(
 
 
 @router.get("/{job_id}", response_model=JobResponse)
-def get_job(job_id: UUID, current_user=Depends(require_engineer), db: Session = Depends(get_db)):
-    """
-    Get a single job's status. Syncs status from Celery backend
-    for in-progress jobs before responding.
-    """
+def get_job(
+    job_id: UUID,
+    current_user=Depends(require_engineer),
+    db: Session = Depends(get_db),
+):
+    """Get a single job's status. Syncs status from Celery for in-progress jobs."""
     job = _get_job_or_404(db, job_id)
     job = _sync_job_status_from_celery(db, job)
     return _serialize_job(job)
+
+
+# BE-W5-050: Standardised envelope endpoint
+@router.get("/{job_id}/envelope", response_model=JobEnvelopeResponse)
+def get_job_envelope(
+    job_id: UUID,
+    current_user=Depends(require_engineer),
+    db: Session = Depends(get_db),
+):
+    """Get a single job wrapped in the standardised result envelope (BE-W5-050)."""
+    job = _get_job_or_404(db, job_id)
+    job = _sync_job_status_from_celery(db, job)
+    return _serialize_envelope(job)
 
 
 class JobProgressResponse(BaseModel):
@@ -296,11 +471,12 @@ class JobProgressResponse(BaseModel):
 
 
 @router.get("/{job_id}/progress", response_model=JobProgressResponse)
-def get_job_progress(job_id: UUID, current_user=Depends(require_engineer), db: Session = Depends(get_db)):
-    """
-    Lightweight polling endpoint returning only progress fields.
-    Syncs status from Celery for in-progress jobs before responding.
-    """
+def get_job_progress(
+    job_id: UUID,
+    current_user=Depends(require_engineer),
+    db: Session = Depends(get_db),
+):
+    """Lightweight polling endpoint returning only progress fields."""
     job = _get_job_or_404(db, job_id)
     job = _sync_job_status_from_celery(db, job)
     return JobProgressResponse(
@@ -314,19 +490,20 @@ def get_job_progress(job_id: UUID, current_user=Depends(require_engineer), db: S
 
 
 @router.delete("/{job_id}", status_code=status.HTTP_204_NO_CONTENT)
-def cancel_job(job_id: UUID, current_user=Depends(require_admin), db: Session = Depends(get_db)):
-    """
-    Revoke a pending or running Celery task and mark the job as REVOKED.
-    Does not interrupt already-executing tasks unless terminate=True is set.
-    """
+def cancel_job(
+    job_id: UUID,
+    current_user=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Revoke a pending or running Celery task and mark the job as REVOKED."""
     job = _get_job_or_404(db, job_id)
-    if job.status in (JobStatus.SUCCESS, JobStatus.FAILURE, JobStatus.REVOKED):
+    if job.status in (JobStatus.SUCCESS, JobStatus.FAILURE, JobStatus.REVOKED,
+                       JobStatus.DEAD_LETTER):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Cannot cancel a job with status '{job.status}'.",
         )
 
-    # Log job revocation before performing the action
     audit_log.log_event(
         db,
         event_type="job_revoked",
@@ -335,27 +512,28 @@ def cancel_job(job_id: UUID, current_user=Depends(require_admin), db: Session = 
             "celery_task_id": job.celery_task_id,
             "job_type": job.job_type.value,
             "previous_status": job.status.value,
-            "payload": job.payload
-        }
+            "payload": job.payload,
+        },
     )
 
     increment_counter("jobs_cancelled", tags={"job_type": job.job_type.value})
-    
     celery_app.control.revoke(job.celery_task_id, terminate=False)
     job.status = JobStatus.REVOKED
     db.commit()
 
 
-# BE-041: Job retry endpoint
+# --------------------------------------------------------------------------- #
+# BE-041 / BE-W5-048: Job retry with taxonomy governance                       #
+# --------------------------------------------------------------------------- #
 
 class JobRetryResponse(BaseModel):
-    """Response from job retry operation."""
     id: UUID
     celery_task_id: str
     job_type: JobType
     status: JobStatus
     retry_count: int
     max_retries: int
+    retry_class: Optional[str] = None
     message: str
 
     model_config = {"from_attributes": True}
@@ -372,40 +550,60 @@ def retry_job(
     current_user=Depends(require_engineer),
     db: Session = Depends(get_db),
 ):
-    """Retry a failed or revoked job.
-    
-    BE-041: Allows authorized users to intentionally retry eligible failed jobs.
-    
-    Retry Policy:
-    - Only FAILED or REVOKED jobs can be retried
-    - Maximum retries per job: configurable via max_retries field (default: 3)
-    - Each retry creates a new Celery task with the original payload
-    - Retry attempts are tracked and audited
-    - Jobs that exceed max_retries are permanently marked as failed
-    
-    Returns:
-        202 Accepted with new job status and incremented retry count
-        400 Bad Request if job is not eligible for retry
-        404 Not Found if job doesn't exist
+    """Retry a failed, revoked, or dead-letter job.
+
+    BE-W5-048: Retry taxonomy governance — retries honour the configured
+    ``retry_class`` and ``max_retries``.  Exhausted dead-letter jobs can be
+    retried manually by operators.
     """
     correlation_id = get_correlation_id()
     job = _get_job_or_404(db, job_id)
-    
-    # Validate job is eligible for retry
-    if job.status not in (JobStatus.FAILURE, JobStatus.REVOKED):
+
+    retryable_statuses = (JobStatus.FAILURE, JobStatus.REVOKED, JobStatus.DEAD_LETTER)
+    if job.status not in retryable_statuses:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Cannot retry job with status '{job.status.value}'. Only FAILED or REVOKED jobs can be retried.",
+            detail=(
+                f"Cannot retry job with status '{job.status.value}'. "
+                f"Only FAILED, REVOKED, or DEAD_LETTER jobs can be retried."
+            ),
         )
-    
-    # Check retry limit
+
     if job.retry_count >= job.max_retries:
+        # BE-W5-048: If dead-letter is enabled, move exhausted jobs there
+        if cfg.JOB_RETRY_DEAD_LETTER_ENABLED and job.status != JobStatus.DEAD_LETTER:
+            job.status = JobStatus.DEAD_LETTER
+            job.dead_letter_reason = (
+                f"Max retries exhausted ({job.max_retries}). "
+                f"Last error: {job.error}"
+            )
+            job.dead_letter_at = datetime.utcnow()
+            job.finished_at = datetime.utcnow()
+            db.commit()
+            db.refresh(job)
+            increment_counter("jobs_dead_lettered", tags={"job_type": job.job_type.value})
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Job has exceeded maximum retry limit ({job.max_retries}) "
+                    f"and has been moved to DEAD_LETTER. Current retry count: {job.retry_count}"
+                ),
+            )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Job has exceeded maximum retry limit ({job.max_retries}). Current retry count: {job.retry_count}",
+            detail=(
+                f"Job has exceeded maximum retry limit ({job.max_retries}). "
+                f"Current retry count: {job.retry_count}"
+            ),
         )
-    
-    # Log retry attempt before performing the action
+
+    # BE-W5-048: Check retry class — at_most_once jobs cannot be auto-retried
+    if job.retry_class == RetryClass.AT_MOST_ONCE.value:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Job has retry class 'at_most_once' and cannot be retried.",
+        )
+
     audit_log.log_event(
         db,
         event_type="job_retry_initiated",
@@ -414,59 +612,64 @@ def retry_job(
             "original_celery_task_id": job.celery_task_id,
             "job_type": job.job_type.value,
             "previous_status": job.status.value,
-            "retry_count": job.retry_count + 1,  # Will be incremented
+            "retry_count": job.retry_count + 1,
             "max_retries": job.max_retries,
+            "retry_class": job.retry_class,
             "payload": job.payload,
             "previous_error": job.error,
             "correlation_id": correlation_id,
-            "initiated_by": getattr(current_user, 'email', 'unknown'),
-        }
+            "initiated_by": getattr(current_user, "email", "unknown"),
+        },
     )
-    
+
     logger.info(
         "Retrying job",
         job_id=str(job.id),
         job_type=job.job_type.value,
         retry_count=job.retry_count + 1,
         max_retries=job.max_retries,
-        correlation_id=correlation_id
+        retry_class=job.retry_class,
+        correlation_id=correlation_id,
     )
-    
-    # Increment retry count and update status
+
     job.retry_count += 1
     job.last_retried_at = datetime.utcnow()
-    job.error = None  # Clear previous error
+    job.error = None
+    job.error_code = None
+    job.error_retryable = None
+    job.error_details = None
     job.status = JobStatus.PENDING
     job.progress = 0.0
     job.started_at = None
     job.finished_at = None
-    
-    # Re-enqueue the job based on its type
+    job.dead_letter_reason = None
+    job.dead_letter_at = None
+
     try:
         payload = json.loads(job.payload) if job.payload else {}
-        
+
         if job.job_type == JobType.SLA_COMPUTATION:
             new_task = enqueue_sla_computation(
                 db,
                 device_id=payload.get("device_id", ""),
                 period=payload.get("period", ""),
-                correlation_id=correlation_id
+                correlation_id=correlation_id,
             )
         elif job.job_type == JobType.BULK_SLA_COMPUTATION:
             new_task = enqueue_bulk_sla_computation(
                 db,
                 device_ids=payload.get("device_ids", []),
                 period=payload.get("period", ""),
-                correlation_id=correlation_id
+                correlation_id=correlation_id,
             )
         elif job.job_type == JobType.WEBHOOK_DISPATCH:
-            # For webhook jobs, re-dispatch with the original payload
             from app.tasks.webhook_tasks import dispatch_webhook_delivery
+
             task_result = dispatch_webhook_delivery.delay(payload)
             job.celery_task_id = task_result.id
             db.commit()
             db.refresh(job)
-            
+
             return JobRetryResponse(
                 id=job.id,
                 celery_task_id=job.celery_task_id,
@@ -474,6 +677,7 @@ def retry_job(
                 status=job.status,
                 retry_count=job.retry_count,
                 max_retries=job.max_retries,
+                retry_class=job.retry_class,
                 message=f"Job retry #{job.retry_count} initiated successfully",
             )
         else:
@@ -481,20 +685,19 @@ def retry_job(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Unsupported job type for retry: {job.job_type.value}",
             )
-        
-        # Update job with new Celery task ID
+
         job.celery_task_id = new_task.celery_task_id
         db.commit()
         db.refresh(job)
-        
+
         logger.info(
             "Job retry enqueued successfully",
             job_id=str(job.id),
             new_celery_task_id=job.celery_task_id,
             retry_count=job.retry_count,
-            correlation_id=correlation_id
+            correlation_id=correlation_id,
         )
-        
+
         return JobRetryResponse(
             id=job.id,
             celery_task_id=job.celery_task_id,
@@ -502,16 +705,19 @@ def retry_job(
             status=job.status,
             retry_count=job.retry_count,
             max_retries=job.max_retries,
+            retry_class=job.retry_class,
             message=f"Job retry #{job.retry_count} initiated successfully",
         )
-        
+
+    except HTTPException:
+        raise
     except Exception as e:
         db.rollback()
         logger.error(
             "Failed to retry job",
             job_id=str(job.id),
             error=str(e),
-            correlation_id=correlation_id
+            correlation_id=correlation_id,
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -519,14 +725,128 @@ def retry_job(
         )
 
 
-# BE-042: Job retention and cleanup endpoints
+# --------------------------------------------------------------------------- #
+# BE-W5-048: Retry taxonomy endpoints                                          #
+# --------------------------------------------------------------------------- #
+
+@router.get("/retry-policies", response_model=List[RetryPolicyResponse])
+def list_retry_policies(
+    current_user=Depends(require_engineer),
+):
+    """List configured retry taxonomy policies per job type (BE-W5-048)."""
+    from app.services.job_cleanup import RETRY_CLASS_DEFAULTS
+    return [
+        RetryPolicyResponse(
+            job_type=jt,
+            retry_class=str(p["retry_class"]),
+            max_retries=int(p["max_retries"]),
+            base_delay_seconds=int(p["base_delay_seconds"]),
+        )
+        for jt, p in sorted(RETRY_CLASS_DEFAULTS.items())
+    ]
+
+
+# BE-W5-048: Dead-letter listing
+@router.get("/dead-letter", response_model=List[DeadLetterSummary])
+def list_dead_letter_jobs(
+    limit: int = Query(50, ge=1, le=200),
+    current_user=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """List jobs in DEAD_LETTER status (BE-W5-048)."""
+    rows = (
+        db.query(Job)
+        .filter(Job.status == JobStatus.DEAD_LETTER)
+        .order_by(Job.dead_letter_at.desc().nullslast())
+        .limit(limit)
+        .all()
+    )
+    return [
+        DeadLetterSummary(
+            id=j.id,
+            celery_task_id=j.celery_task_id,
+            job_type=j.job_type,
+            dead_letter_reason=j.dead_letter_reason,
+            dead_letter_at=j.dead_letter_at.isoformat() if j.dead_letter_at else None,
+            retry_count=j.retry_count,
+            max_retries=j.max_retries,
+            created_at=j.created_at.isoformat(),
+        )
+        for j in rows
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# BE-W5-047: Lease heartbeat / reclamation endpoints                           #
+# --------------------------------------------------------------------------- #
+
+@router.post("/{job_id}/heartbeat", status_code=status.HTTP_200_OK)
+def record_job_heartbeat(
+    job_id: UUID,
+    worker_id: str = Query(..., description="Worker identifier"),
+    current_user=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Record a lease heartbeat for a running job (BE-W5-047).
+
+    Internal endpoint used by workers to extend their lease on a job.
+    """
+    job = _get_job_or_404(db, job_id)
+    if job.status not in (JobStatus.STARTED, JobStatus.PENDING):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Cannot heartbeat a job with status '{job.status.value}'.",
+        )
+
+    updated = heartbeat_job(
+        db,
+        job.celery_task_id,
+        worker_id,
+        timeout_seconds=cfg.JOB_LEASE_TIMEOUT_SECONDS,
+    )
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update heartbeat.",
+        )
+    return {"job_id": str(job_id), "heartbeat_at": updated.heartbeat_at.isoformat()}
+
+
+@router.post("/reclaim-stale-leases", response_model=LeaseReclamationResponse)
+def reclaim_stale_job_leases(
+    payload: LeaseReclamationRequest,
+    current_user=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Reclaim jobs with expired worker leases (BE-W5-047).
+
+    Stale leases are returned to PENDING so another worker can pick them up.
+    """
+    if not cfg.JOB_LEASE_RECLAMATION_ENABLED:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Lease reclamation is disabled in configuration.",
+        )
+
+    result = reclaim_stale_leases(
+        db,
+        timeout_seconds=payload.timeout_seconds,
+        batch_size=payload.batch_size,
+        dry_run=payload.dry_run,
+    )
+    return LeaseReclamationResponse(**result)
+
+
+# --------------------------------------------------------------------------- #
+# BE-W5-052: Retention tiering endpoints                                       #
+# --------------------------------------------------------------------------- #
 
 @router.get("/retention-stats", response_model=JobRetentionStatsResponse)
-def get_job_retention_stats(current_user=Depends(require_admin), db: Session = Depends(get_db)):
-    """Get current job retention statistics without deleting anything.
-    
-    BE-042: Provides visibility into job storage usage and aging.
-    """
+def get_job_retention_stats(
+    current_user=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Get current job retention statistics including protection flags (BE-W5-052)."""
     cleanup_service = JobCleanupService(db)
     return cleanup_service.get_retention_stats()
 
@@ -535,47 +855,99 @@ def get_job_retention_stats(current_user=Depends(require_admin), db: Session = D
 def cleanup_old_jobs(
     payload: JobCleanupRequest,
     current_user=Depends(require_admin),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ):
-    """Clean up old completed and failed jobs based on retention policy.
+    """Clean up old jobs based on retention tiering policy (BE-W5-052).
 
-    BE-042: Removes old job records to prevent unbounded database growth.
-    - Successful/revoked jobs: default 30 day retention
-    - Failed jobs: default 90 day retention (preserved longer for debugging)
-
-    Use dry_run=True to preview what would be deleted without actually deleting.
-    Note: quarantined jobs are excluded from automatic cleanup — they are
-    preserved until operators explicitly release or remove them.
+    Protected records (under investigation, under dispute, audit-critical)
+    are excluded from standard cleanup sweeps.
     """
     cleanup_service = JobCleanupService(db)
 
     result = cleanup_service.cleanup_old_jobs(
-        successful_retention_days=payload.successful_retention_days,
-        failed_retention_days=payload.failed_retention_days,
+        retention_days=payload.retention_days,
         dry_run=payload.dry_run,
+        batch_size=payload.batch_size,
     )
 
-    # Log the cleanup operation
     audit_log.log_event(
         db,
         event_type="job_cleanup_executed",
         details={
             "total_deleted": result["total_deleted"],
-            "successful_deleted": result["successful_jobs_deleted"],
-            "failed_deleted": result["failed_jobs_deleted"],
-            "revoked_deleted": result["revoked_jobs_deleted"],
+            "deleted_by_status": result["deleted_by_status"],
             "dry_run": payload.dry_run,
-            "executed_by": getattr(current_user, 'email', 'unknown'),
-        }
+            "executed_by": getattr(current_user, "email", "unknown"),
+        },
     )
 
     return JobCleanupResponse(**result)
 
 
-# BE-W5-054: Poison-message quarantine endpoints
+@router.post("/cleanup-audit-critical", response_model=AuditCriticalCleanupResponse)
+def cleanup_audit_critical_jobs(
+    retention_days: int = 365,
+    dry_run: bool = False,
+    current_user=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Clean up audit-critical jobs past their extended retention window (BE-W5-052)."""
+    cleanup_service = JobCleanupService(db)
+    result = cleanup_service.cleanup_audit_critical(
+        retention_days=retention_days,
+        dry_run=dry_run,
+    )
+    return AuditCriticalCleanupResponse(**result)
+
+
+# BE-W5-052: Protection flag management
+@router.patch("/{job_id}/protection-flags", response_model=JobResponse)
+def update_job_protection_flags(
+    job_id: UUID,
+    payload: ProtectionFlagRequest,
+    current_user=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Set investigation or dispute flags on a job (BE-W5-052).
+
+    Flagged records are protected from all automatic cleanup sweeps.
+    """
+    job = _get_job_or_404(db, job_id)
+
+    if payload.under_investigation is not None:
+        job.under_investigation = payload.under_investigation
+        audit_log.log_event(
+            db,
+            event_type="job_investigation_flag_changed",
+            details={
+                "job_id": str(job.id),
+                "under_investigation": payload.under_investigation,
+                "updated_by": getattr(current_user, "email", "unknown"),
+            },
+        )
+
+    if payload.under_dispute is not None:
+        job.under_dispute = payload.under_dispute
+        audit_log.log_event(
+            db,
+            event_type="job_dispute_flag_changed",
+            details={
+                "job_id": str(job.id),
+                "under_dispute": payload.under_dispute,
+                "updated_by": getattr(current_user, "email", "unknown"),
+            },
+        )
+
+    db.commit()
+    db.refresh(job)
+    return _serialize_job(job)
+
+
+# --------------------------------------------------------------------------- #
+# BE-W5-054: Poison-message quarantine endpoints                               #
+# --------------------------------------------------------------------------- #
 
 class QuarantinedJobSummary(BaseModel):
-    """Summary row for quarantined-job listings."""
     id: UUID
     celery_task_id: str
     job_type: JobType
@@ -602,17 +974,11 @@ def list_quarantined_jobs(
     current_user=Depends(require_admin),
     db: Session = Depends(get_db),
 ):
-    """List quarantined jobs (BE-W5-054).
-
-    Quarantined jobs are poison messages that have repeatedly crashed workers;
-    they are excluded from normal retry sweeps until an operator inspects and
-    releases them. ``payload_hash`` lets operators group poison messages by
-    fingerprint.
-    """
+    """List quarantined jobs (BE-W5-054)."""
     rows = (
         db.query(Job)
         .filter(Job.status == JobStatus.QUARANTINED)
-        .order_by(Job.quarantined_at.desc().nullslast())  # type: ignore[attr-defined]
+        .order_by(Job.quarantined_at.desc().nullslast())
         .limit(limit)
         .all()
     )
@@ -642,12 +1008,7 @@ def release_job_from_quarantine(
     current_user=Depends(require_admin),
     db: Session = Depends(get_db),
 ):
-    """Release a quarantined job back into the retry pipeline (BE-W5-054).
-
-    Resets retry bookkeeping, clears quarantine metadata, and re-enqueues
-    the underlying Celery task based on ``job_type``. Use this after the
-    underlying poison-payload root cause has been remediated.
-    """
+    """Release a quarantined job back into the retry pipeline (BE-W5-054)."""
     correlation_id = get_correlation_id()
     job = _get_job_or_404(db, job_id)
 
@@ -671,12 +1032,14 @@ def release_job_from_quarantine(
         },
     )
 
-    # Reset quarantine metadata & retry bookkeeping.
     job.quarantined_at = None
     job.quarantine_reason = None
     job.payload_hash = None
     job.retry_count = 0
     job.error = None
+    job.error_code = None
+    job.error_retryable = None
+    job.error_details = None
     job.finished_at = None
     job.started_at = None
     job.progress = 0.0
@@ -701,6 +1064,7 @@ def release_job_from_quarantine(
             )
         elif job.job_type == JobType.WEBHOOK_DISPATCH:
             from app.tasks.webhook_tasks import dispatch_webhook_delivery
+
             delivery_id = payload.get("delivery_id") or payload.get("idempotency_key")
             if not delivery_id:
                 raise HTTPException(
@@ -750,4 +1114,3 @@ def release_job_from_quarantine(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to release quarantine: {str(exc)}",
         )
-

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -186,6 +186,38 @@ class Settings(BaseSettings):
     WEBHOOK_QUEUE_SCALE_UP_THRESHOLD: int = 100
     WEBHOOK_QUEUE_SCALE_DOWN_THRESHOLD: int = 10
 
+    # ── BE-W5-047: Job lease heartbeat ────────────────────────────────────
+    JOB_LEASE_HEARTBEAT_INTERVAL_SECONDS: int = 30
+    JOB_LEASE_TIMEOUT_SECONDS: int = 120
+    JOB_LEASE_RECLAMATION_ENABLED: bool = True
+    JOB_LEASE_RECLAMATION_BATCH_SIZE: int = 50
+
+    # ── BE-W5-048: Retry taxonomy governance ──────────────────────────────
+    JOB_RETRY_CLASS_DEFAULTS: str = (
+        "sla_computation:exponential_backoff:3:30,"
+        "bulk_sla_computation:exponential_backoff:2:60,"
+        "webhook_dispatch:at_least_once:5:30,"
+        "webhook_dr_replay:at_most_once:1:60"
+    )
+    # Format per entry: "job_type:retry_class:max_retries:base_delay_seconds"
+    JOB_RETRY_DEAD_LETTER_ENABLED: bool = True
+    JOB_RETRY_BACKOFF_MAX_DELAY_SECONDS: int = 3600
+    JOB_RETRY_BACKOFF_MULTIPLIER: float = 2.0
+    JOB_RETRY_JITTER_SECONDS: int = 5
+
+    # ── BE-W5-052: Retention tiering ──────────────────────────────────────
+    JOB_RETENTION_SUCCESS_DAYS: int = 30
+    JOB_RETENTION_FAILURE_DAYS: int = 90
+    JOB_RETENTION_REVOKED_DAYS: int = 30
+    JOB_RETENTION_QUARANTINED_DAYS: int = 180
+    JOB_RETENTION_DEAD_LETTER_DAYS: int = 180
+    JOB_RETENTION_AUDIT_CRITICAL_DAYS: int = 365
+    JOB_RETENTION_INVESTIGATION_PROTECTED: bool = True
+    JOB_RETENTION_DISPUTE_PROTECTED: bool = True
+    JOB_RETENTION_DRY_RUN_DEFAULT: bool = False
+    JOB_RETENTION_CLEANUP_BATCH_SIZE: int = 1000
+    JOB_RETENTION_CLEANUP_METRICS_ENABLED: bool = True
+
     # ── DB pool ───────────────────────────────────────────────────────────
     DB_POOL_SATURATION_THRESHOLD: float = 0.9
     DB_POOL_REJECT_AFTER_SECONDS: int = 30

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -1,6 +1,9 @@
 import uuid
 from datetime import datetime
-from sqlalchemy import Column, DateTime, Enum, Enum as SAEnum, Float, Integer, JSON, String, Text
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel as PydanticBaseModel
+from sqlalchemy import Boolean, Column, DateTime, Enum, Enum as SAEnum, Float, Integer, JSON, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 import enum
 
@@ -14,6 +17,7 @@ class JobStatus(str, enum.Enum):
     FAILURE = "failure"
     REVOKED = "revoked"
     QUARANTINED = "quarantined"  # BE-W5-054: poison-message quarantine
+    DEAD_LETTER = "dead_letter"  # BE-W5-048: terminal dead-letter for exhausted retries
 
 
 class JobType(str, enum.Enum):
@@ -21,6 +25,48 @@ class JobType(str, enum.Enum):
     WEBHOOK_DISPATCH = "webhook_dispatch"
     BULK_SLA_COMPUTATION = "bulk_sla_computation"
     WEBHOOK_DR_REPLAY = "webhook_dr_replay"  # BE-W5-045: disaster-recovery replay
+
+
+class RetryClass(str, enum.Enum):
+    """BE-W5-048: Standardised retry taxonomy per job type."""
+    AT_MOST_ONCE = "at_most_once"          # No automatic retry; manual only
+    AT_LEAST_ONCE = "at_least_once"         # Retry until success (with backoff cap)
+    EXPONENTIAL_BACKOFF = "exponential_backoff"  # Progressive backoff with jitter
+
+
+# --------------------------------------------------------------------------- #
+# BE-W5-050: Standardised job result envelope                                  #
+# --------------------------------------------------------------------------- #
+
+class JobErrorDetail(PydanticBaseModel):
+    """Structured error metadata carried inside the job result envelope."""
+    code: str                                    # Machine-readable error code (e.g. "SLA_TIMEOUT")
+    message: str                                 # Human-readable description
+    retryable: bool = False                      # Whether a retry could succeed
+    details: Optional[Dict[str, Any]] = None     # Optional contextual payload
+
+
+class JobResultEnvelope(PydanticBaseModel):
+    """Standard envelope returned by every job status endpoint.
+
+    BE-W5-050: Operators and FE clients can parse job outcomes uniformly
+    regardless of ``job_type``.  The envelope is always present even when
+    the job is still running (``status`` will be ``pending``/``started`` and
+    ``result``/``error`` will be ``None``).
+    """
+    job_id: str
+    celery_task_id: str
+    job_type: str
+    status: str
+    progress: float = 0.0
+    result: Optional[Dict[str, Any]] = None
+    error: Optional[JobErrorDetail] = None
+    retry_count: int = 0
+    max_retries: int = 3
+    retry_class: Optional[str] = None
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    created_at: Optional[str] = None
 
 
 class Job(Base):
@@ -33,6 +79,10 @@ class Job(Base):
     payload = Column(Text, nullable=True)        # JSON-encoded input params
     result = Column(Text, nullable=True)         # JSON-encoded result
     error = Column(Text, nullable=True)
+    # BE-W5-050: typed error metadata
+    error_code = Column(String(64), nullable=True, index=True)
+    error_retryable = Column(Boolean, nullable=True)
+    error_details = Column(JSON, nullable=True)
     progress = Column(Float, default=0.0)        # 0.0 – 100.0
     progress_details = Column(JSON, nullable=True)  # Structured progress information
     partial_results = Column(JSON, nullable=True)   # Partial results for bulk operations
@@ -40,7 +90,11 @@ class Job(Base):
     # BE-041: Retry tracking
     retry_count = Column(Integer, default=0, nullable=False)  # Number of times job has been retried
     max_retries = Column(Integer, default=3, nullable=False)  # Maximum allowed retries for this job
+    retry_class = Column(String(32), nullable=True)  # BE-W5-048: retry taxonomy class
     last_retried_at = Column(DateTime, nullable=True)  # When the job was last retried
+    # BE-W5-048: dead-letter metadata
+    dead_letter_reason = Column(Text, nullable=True)
+    dead_letter_at = Column(DateTime, nullable=True)
     started_at = Column(DateTime, nullable=True)
     finished_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
@@ -49,3 +103,12 @@ class Job(Base):
     payload_hash = Column(String(64), nullable=True, index=True)
     quarantine_reason = Column(Text, nullable=True)
     quarantined_at = Column(DateTime, nullable=True)
+    # BE-W5-047: lease heartbeat for stuck-task reclamation
+    worker_id = Column(String(128), nullable=True, index=True)
+    heartbeat_at = Column(DateTime, nullable=True)
+    lease_expires_at = Column(DateTime, nullable=True)
+    # BE-W5-052: retention-tier protection flags
+    under_investigation = Column(Boolean, default=False, nullable=False, index=True)
+    under_dispute = Column(Boolean, default=False, nullable=False, index=True)
+    # BE-W5-052: audit-critical flag (retention tier)
+    audit_critical = Column(Boolean, default=False, nullable=False)

--- a/app/services/job_cleanup.py
+++ b/app/services/job_cleanup.py
@@ -1,152 +1,241 @@
-"""Job retention and cleanup service.
+"""Job retention, cleanup, and lease reclamation service.
 
 BE-042: Provides job retention and cleanup policies to prevent unbounded growth
 of job records and maintain database performance.
+
+BE-W5-047: Stale lease reclamation for stuck-task recovery.
+
+BE-W5-052: Retention tiering with configurable windows per job class/status,
+investigation/dispute protection, audit-critical preservation, and metrics.
 """
 from datetime import datetime, timedelta
-from typing import Optional
-from sqlalchemy import delete
+from typing import Dict, List, Optional
+from sqlalchemy import delete, update
 from sqlalchemy.orm import Session
 
 from app.models.job import Job, JobStatus
+from app.services.audit_log import audit_log
+from app.services.metrics import increment_counter, gauge
+from app.utils.logging import get_structured_logger
 
+logger = get_structured_logger("job_cleanup")
+
+
+# --------------------------------------------------------------------------- #
+# BE-W5-048: Per-job-type retry taxonomy defaults                             #
+# --------------------------------------------------------------------------- #
+
+RETRY_CLASS_DEFAULTS: Dict[str, Dict[str, object]] = {
+    "sla_computation": {
+        "retry_class": "exponential_backoff",
+        "max_retries": 3,
+        "base_delay_seconds": 30,
+    },
+    "bulk_sla_computation": {
+        "retry_class": "exponential_backoff",
+        "max_retries": 2,
+        "base_delay_seconds": 60,
+    },
+    "webhook_dispatch": {
+        "retry_class": "at_least_once",
+        "max_retries": 5,
+        "base_delay_seconds": 30,
+    },
+    "webhook_dr_replay": {
+        "retry_class": "at_most_once",
+        "max_retries": 1,
+        "base_delay_seconds": 60,
+    },
+}
+
+
+def get_retry_policy(job_type: str) -> Dict[str, object]:
+    """Return the retry taxonomy defaults for *job_type*.
+
+    BE-W5-048: Config-driven; falls back to a sensible default when the job
+    type is unknown.
+    """
+    return RETRY_CLASS_DEFAULTS.get(
+        job_type,
+        {"retry_class": "at_least_once", "max_retries": 3, "base_delay_seconds": 30},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# BE-W5-047: Lease / heartbeat helpers                                        #
+# --------------------------------------------------------------------------- #
+
+
+def heartbeat_job(db: Session, celery_task_id: str, worker_id: str, timeout_seconds: int = 120) -> Optional[Job]:
+    """Record a heartbeat for *celery_task_id*.
+
+    Returns the updated Job or None if no matching record exists.
+    """
+    job = db.query(Job).filter(Job.celery_task_id == celery_task_id).first()
+    if not job:
+        return None
+
+    now = datetime.utcnow()
+    job.heartbeat_at = now
+    job.lease_expires_at = now + timedelta(seconds=timeout_seconds)
+    job.worker_id = worker_id
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+def reclaim_stale_leases(
+    db: Session,
+    timeout_seconds: int = 120,
+    batch_size: int = 50,
+    dry_run: bool = False,
+) -> Dict[str, object]:
+    """Find and reclaim jobs whose lease has expired.
+
+    BE-W5-047: Stale leases are reset to PENDING so another worker can pick
+    them up.  Single-owner guarantee: only jobs with ``lease_expires_at`` in
+    the past AND a non-null ``worker_id`` are candidates.
+    """
+    now = datetime.utcnow()
+    stale = (
+        db.query(Job)
+        .filter(
+            Job.lease_expires_at.isnot(None),
+            Job.lease_expires_at < now,
+            Job.worker_id.isnot(None),
+            Job.status.in_([JobStatus.STARTED]),
+        )
+        .limit(batch_size)
+        .all()
+    )
+
+    reclaimed: List[str] = []
+    for job in stale:
+        prev_worker = job.worker_id
+        prev_lease = job.lease_expires_at
+        if not dry_run:
+            job.worker_id = None
+            job.heartbeat_at = None
+            job.lease_expires_at = None
+            job.status = JobStatus.PENDING
+            job.started_at = None
+            job.error = (
+                f"Lease expired (worker={prev_worker}, "
+                f"expired={prev_lease.isoformat() if prev_lease else 'N/A'}); "
+                f"reclaimed at {now.isoformat()}"
+            )
+            # BE-W5-047: reclamation audit event
+            try:
+                audit_log.log_event(
+                    db,
+                    event_type="job_lease_reclaimed",
+                    details={
+                        "job_id": str(job.id),
+                        "celery_task_id": job.celery_task_id,
+                        "job_type": job.job_type.value,
+                        "previous_worker": prev_worker,
+                        "lease_expired": prev_lease.isoformat() if prev_lease else None,
+                        "reclaimed_at": now.isoformat(),
+                    },
+                )
+            except Exception:
+                logger.exception("Failed to write lease-reclamation audit event for job=%s", job.id)
+            increment_counter("job_leases_reclaimed", tags={"job_type": job.job_type.value})
+        reclaimed.append(str(job.id))
+
+    if not dry_run and reclaimed:
+        db.commit()
+
+    logger.info(
+        "Lease reclamation scanned %d stale leases; reclaimed=%d dry_run=%s",
+        len(stale), len(reclaimed), dry_run,
+    )
+    return {
+        "stale_leases_found": len(stale),
+        "reclaimed": len(reclaimed),
+        "dry_run": dry_run,
+        "checked_at": now.isoformat(),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# BE-W5-052: Retention tiering                                                #
+# --------------------------------------------------------------------------- #
 
 class JobCleanupService:
-    """Manages job retention and cleanup policies."""
-    
-    # Default retention periods
-    SUCCESSFUL_JOB_RETENTION_DAYS = 30  # Keep successful jobs for 30 days
-    FAILED_JOB_RETENTION_DAYS = 90      # Keep failed jobs for 90 days (for debugging)
-    
+    """Manages job retention and cleanup policies with tiering.
+
+    BE-W5-052: Retention windows are configurable by job class and state.
+    Records flagged ``under_investigation`` or ``under_dispute`` are never
+    removed.  Audit-critical jobs use an extended retention window.
+    """
+
     def __init__(self, db: Session):
         self.db = db
-    
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                          #
+    # ------------------------------------------------------------------ #
+
     def cleanup_old_jobs(
         self,
-        successful_retention_days: Optional[int] = None,
-        failed_retention_days: Optional[int] = None,
+        *,
+        retention_days: Optional[Dict[str, int]] = None,
         dry_run: bool = False,
         batch_size: int = 1000,
     ) -> dict:
-        """Clean up old completed and failed jobs based on retention policy.
-        
-        Args:
-            successful_retention_days: Days to keep successful jobs (default: 30)
-            failed_retention_days: Days to keep failed jobs (default: 90)
-            dry_run: If True, only count what would be deleted without deleting
-            batch_size: Process deletions in batches to avoid long-running transactions
-            
-        Returns:
-            Dictionary with cleanup statistics
+        """Clean up old jobs using configurable retention windows.
+
+        The ``retention_days`` dict maps ``JobStatus.value`` → days.  If
+        omitted, sensible defaults are used (see :meth:`_default_retention`).
+
+        Jobs flagged ``under_investigation`` or ``under_dispute`` are always
+        skipped regardless of age.  Audit-critical jobs use a separate
+        extended window.
         """
-        successful_retention_days = successful_retention_days or self.SUCCESSFUL_JOB_RETENTION_DAYS
-        failed_retention_days = failed_retention_days or self.FAILED_JOB_RETENTION_DAYS
-        
-        cutoff_success = datetime.utcnow() - timedelta(days=successful_retention_days)
-        cutoff_failed = datetime.utcnow() - timedelta(days=failed_retention_days)
-        
-        total_deleted = 0
-        stats = {
-            "successful_jobs_deleted": 0,
-            "failed_jobs_deleted": 0,
-            "revoked_jobs_deleted": 0,
-            "cutoff_successful": cutoff_success.isoformat(),
-            "cutoff_failed": cutoff_failed.isoformat(),
-            "dry_run": dry_run,
-        }
-        
-        # Clean up old successful jobs
-        success_count = self._count_jobs_by_status(JobStatus.SUCCESS, cutoff_success)
-        stats["successful_jobs_deleted"] = success_count
-        
-        if not dry_run and success_count > 0:
-            deleted = self._delete_jobs_by_status(
-                JobStatus.SUCCESS, cutoff_success, batch_size
-            )
-            total_deleted += deleted
-            stats["successful_jobs_deleted"] = deleted
-        
-        # Clean up old failed jobs
-        failed_count = self._count_jobs_by_status(JobStatus.FAILURE, cutoff_failed)
-        stats["failed_jobs_deleted"] = failed_count
-        
-        if not dry_run and failed_count > 0:
-            deleted = self._delete_jobs_by_status(
-                JobStatus.FAILURE, cutoff_failed, batch_size
-            )
-            total_deleted += deleted
-            stats["failed_jobs_deleted"] = deleted
-        
-        # Clean up old revoked jobs (same retention as successful)
-        revoked_count = self._count_jobs_by_status(JobStatus.REVOKED, cutoff_success)
-        stats["revoked_jobs_deleted"] = revoked_count
-        
-        if not dry_run and revoked_count > 0:
-            deleted = self._delete_jobs_by_status(
-                JobStatus.REVOKED, cutoff_success, batch_size
-            )
-            total_deleted += deleted
-            stats["revoked_jobs_deleted"] = deleted
-        
-        stats["total_deleted"] = total_deleted
-        
-        return stats
-    
-    def _count_jobs_by_status(self, status: JobStatus, cutoff_date: datetime) -> int:
-        """Count jobs with given status older than cutoff date."""
-        return (
-            self.db.query(Job)
-            .filter(
-                Job.status == status,
-                Job.finished_at < cutoff_date,
-            )
-            .count()
-        )
-    
-    def _delete_jobs_by_status(
-        self,
-        status: JobStatus,
-        cutoff_date: datetime,
-        batch_size: int,
-    ) -> int:
-        """Delete jobs with given status older than cutoff date in batches."""
-        total_deleted = 0
-        
-        while True:
-            # Get a batch of job IDs to delete
-            job_ids = (
-                self.db.query(Job.id)
-                .filter(
-                    Job.status == status,
-                    Job.finished_at < cutoff_date,
-                )
-                .limit(batch_size)
-                .all()
-            )
-            
-            job_ids = [jid[0] for jid in job_ids]  # Extract UUIDs from results
-            
-            if not job_ids:
-                break
-            
-            # Delete the batch
-            delete_stmt = delete(Job).where(Job.id.in_(job_ids))
-            self.db.execute(delete_stmt)
-            self.db.commit()
-            
-            total_deleted += len(job_ids)
-            
-            # If we got fewer than batch_size, we're done
-            if len(job_ids) < batch_size:
-                break
-        
-        return total_deleted
-    
-    def get_retention_stats(self) -> dict:
-        """Get current job retention statistics without deleting anything."""
+        windows = retention_days or self._default_retention()
         now = datetime.utcnow()
-        
-        # Count jobs by status and age
+        total_deleted = 0
+        stats: dict = {"dry_run": dry_run, "deleted_by_status": {}}
+
+        for status_value, days in windows.items():
+            try:
+                status = JobStatus(status_value)
+            except ValueError:
+                logger.warning("Unknown JobStatus in retention config: %s", status_value)
+                continue
+
+            cutoff = now - timedelta(days=days)
+            count = self._count_eligible(status, cutoff)
+            stats["deleted_by_status"][status_value] = count
+
+            if not dry_run and count > 0:
+                deleted = self._delete_eligible(status, cutoff, batch_size)
+                total_deleted += deleted
+                stats["deleted_by_status"][status_value] = deleted
+
+        stats["total_deleted"] = total_deleted
+        stats["cutoffs"] = {
+            s: (now - timedelta(days=d)).isoformat() for s, d in windows.items()
+        }
+
+        if not dry_run and total_deleted > 0:
+            audit_log.log_event(
+                self.db,
+                event_type="job_cleanup_executed",
+                details=stats,
+            )
+            increment_counter("job_cleanup_deleted", value=total_deleted)
+
+        return stats
+
+    def get_retention_stats(self) -> dict:
+        """Get current job retention statistics without deleting anything.
+
+        BE-W5-052: Includes per-status counts, age buckets, and protected
+        record counts (investigation / dispute / audit-critical).
+        """
+        now = datetime.utcnow()
         stats = {
             "total_jobs": self.db.query(Job).count(),
             "by_status": {},
@@ -154,37 +243,206 @@ class JobCleanupService:
                 "older_than_30_days": 0,
                 "older_than_60_days": 0,
                 "older_than_90_days": 0,
-            }
+                "older_than_180_days": 0,
+                "older_than_365_days": 0,
+            },
+            "protected": {
+                "under_investigation": self.db.query(Job)
+                .filter(Job.under_investigation.is_(True))
+                .count(),
+                "under_dispute": self.db.query(Job)
+                .filter(Job.under_dispute.is_(True))
+                .count(),
+                "audit_critical": self.db.query(Job)
+                .filter(Job.audit_critical.is_(True))
+                .count(),
+            },
         }
-        
-        # Count by status
+
         for status in JobStatus:
-            count = (
-                self.db.query(Job)
-                .filter(Job.status == status)
-                .count()
+            stats["by_status"][status.value] = (
+                self.db.query(Job).filter(Job.status == status).count()
             )
-            stats["by_status"][status.value] = count
-        
-        # Count by age
-        cutoff_30 = now - timedelta(days=30)
-        cutoff_60 = now - timedelta(days=60)
-        cutoff_90 = now - timedelta(days=90)
-        
-        stats["by_age"]["older_than_30_days"] = (
-            self.db.query(Job)
-            .filter(Job.created_at < cutoff_30)
-            .count()
-        )
-        stats["by_age"]["older_than_60_days"] = (
-            self.db.query(Job)
-            .filter(Job.created_at < cutoff_60)
-            .count()
-        )
-        stats["by_age"]["older_than_90_days"] = (
-            self.db.query(Job)
-            .filter(Job.created_at < cutoff_90)
-            .count()
-        )
-        
+
+        for label, days in [
+            ("older_than_30_days", 30),
+            ("older_than_60_days", 60),
+            ("older_than_90_days", 90),
+            ("older_than_180_days", 180),
+            ("older_than_365_days", 365),
+        ]:
+            cutoff = now - timedelta(days=days)
+            stats["by_age"][label] = (
+                self.db.query(Job).filter(Job.created_at < cutoff).count()
+            )
+
         return stats
+
+    # ------------------------------------------------------------------ #
+    # Helpers                                                             #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _default_retention() -> Dict[str, int]:
+        """Return the default retention windows (in days) per status.
+
+        BE-W5-052: Mirrors config defaults. Callers may override.
+        """
+        from app.core.config import settings as cfg
+
+        return {
+            JobStatus.SUCCESS.value: cfg.JOB_RETENTION_SUCCESS_DAYS,
+            JobStatus.FAILURE.value: cfg.JOB_RETENTION_FAILURE_DAYS,
+            JobStatus.REVOKED.value: cfg.JOB_RETENTION_REVOKED_DAYS,
+            JobStatus.QUARANTINED.value: cfg.JOB_RETENTION_QUARANTINED_DAYS,
+            JobStatus.DEAD_LETTER.value: cfg.JOB_RETENTION_DEAD_LETTER_DAYS,
+        }
+
+    def _build_base_query(self, status: JobStatus, cutoff: datetime):
+        """Return a base query for eligible jobs, honouring protection flags.
+
+        BE-W5-052: Jobs under investigation, dispute, or flagged
+        audit-critical are never eligible for cleanup via the standard
+        retention sweeps.  Audit-critical jobs use an extended window
+        cleaned via :meth:`cleanup_audit_critical`.
+        """
+        q = (
+            self.db.query(Job)
+            .filter(
+                Job.status == status,
+                Job.finished_at < cutoff,
+                # Protected records are NEVER removed by standard cleanup
+                Job.under_investigation.isnot(True),
+                Job.under_dispute.isnot(True),
+                # Audit-critical jobs always use their own extended window
+                Job.audit_critical.isnot(True),
+            )
+        )
+        return q
+
+    def _count_eligible(self, status: JobStatus, cutoff: datetime) -> int:
+        return self._build_base_query(status, cutoff).count()
+
+    def _delete_eligible(
+        self, status: JobStatus, cutoff: datetime, batch_size: int
+    ) -> int:
+        total = 0
+        while True:
+            ids = [
+                row[0]
+                for row in self._build_base_query(status, cutoff)
+                .with_entities(Job.id)
+                .limit(batch_size)
+                .all()
+            ]
+            if not ids:
+                break
+            self.db.execute(delete(Job).where(Job.id.in_(ids)))
+            self.db.commit()
+            total += len(ids)
+            if len(ids) < batch_size:
+                break
+        return total
+
+    # ------------------------------------------------------------------ #
+    # BE-W5-052: Audit-critical cleanup (extended window)                  #
+    # ------------------------------------------------------------------ #
+
+    def cleanup_audit_critical(
+        self,
+        retention_days: int = 365,
+        dry_run: bool = False,
+        batch_size: int = 500,
+    ) -> dict:
+        """Clean up audit-critical jobs past their extended window.
+
+        Audit-critical records are preserved longer than regular jobs for
+        forensic purposes.  This sweep runs less frequently.
+        """
+        from app.core.config import settings as cfg
+
+        retention_days = retention_days or cfg.JOB_RETENTION_AUDIT_CRITICAL_DAYS
+        cutoff = datetime.utcnow() - timedelta(days=retention_days)
+
+        eligible = (
+            self.db.query(Job)
+            .filter(
+                Job.audit_critical.is_(True),
+                Job.finished_at < cutoff,
+                Job.under_investigation.isnot(True),
+                Job.under_dispute.isnot(True),
+            )
+        )
+
+        count = eligible.count()
+        deleted = 0
+
+        if not dry_run and count > 0:
+            while True:
+                ids = [
+                    row[0]
+                    for row in eligible.with_entities(Job.id).limit(batch_size).all()
+                ]
+                if not ids:
+                    break
+                self.db.execute(delete(Job).where(Job.id.in_(ids)))
+                self.db.commit()
+                deleted += len(ids)
+                if len(ids) < batch_size:
+                    break
+
+        return {
+            "audit_critical_eligible": count,
+            "audit_critical_deleted": deleted if not dry_run else count,
+            "dry_run": dry_run,
+            "cutoff": cutoff.isoformat(),
+            "retention_days": retention_days,
+        }
+
+    # ------------------------------------------------------------------ #
+    # BE-W5-052: Protection flag management                               #
+    # ------------------------------------------------------------------ #
+
+    def set_investigation_flag(self, job_id: str, under_investigation: bool = True) -> Optional[Job]:
+        """Toggle the ``under_investigation`` flag for a job.
+
+        Returns the updated Job or None if not found.
+        """
+        job = self.db.query(Job).filter(Job.id == job_id).first()
+        if not job:
+            return None
+        job.under_investigation = under_investigation
+        self.db.commit()
+        self.db.refresh(job)
+
+        audit_log.log_event(
+            self.db,
+            event_type="job_investigation_flag_changed",
+            details={
+                "job_id": job_id,
+                "under_investigation": under_investigation,
+            },
+        )
+        return job
+
+    def set_dispute_flag(self, job_id: str, under_dispute: bool = True) -> Optional[Job]:
+        """Toggle the ``under_dispute`` flag for a job.
+
+        Returns the updated Job or None if not found.
+        """
+        job = self.db.query(Job).filter(Job.id == job_id).first()
+        if not job:
+            return None
+        job.under_dispute = under_dispute
+        self.db.commit()
+        self.db.refresh(job)
+
+        audit_log.log_event(
+            self.db,
+            event_type="job_dispute_flag_changed",
+            details={
+                "job_id": job_id,
+                "under_dispute": under_dispute,
+            },
+        )
+        return job

--- a/app/tasks/sla_tasks.py
+++ b/app/tasks/sla_tasks.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from celery import Task
 
 from app.tasks.celery_app import celery_app
+from app.core.config import settings as cfg
 from app.db.session import SessionLocal
 from app.models.job import Job, JobStatus, JobType
 from app.models.webhook import WebhookEvent
@@ -39,7 +40,8 @@ def _hash_job_payload(job: Job) -> str:
 
 
 class DatabaseTask(Task):
-    """Base task that provides a scoped DB session and updates Job records."""
+    """Base task that provides a scoped DB session, updates Job records,
+    and manages lease heartbeats for BE-W5-047."""
 
     abstract = True
     _db = None
@@ -55,6 +57,17 @@ class DatabaseTask(Task):
         if job:
             job.status = JobStatus.STARTED
             job.started_at = datetime.utcnow()
+            # BE-W5-047: Initialize lease on start
+            job.heartbeat_at = datetime.utcnow()
+            job.lease_expires_at = datetime.utcnow() + timedelta(seconds=cfg.JOB_LEASE_TIMEOUT_SECONDS)
+            db.commit()
+
+    def _heartbeat(self, db, celery_task_id: str):
+        """BE-W5-047: Extend the lease on a running job."""
+        job = self._get_job(db, celery_task_id)
+        if job and job.status == JobStatus.STARTED:
+            job.heartbeat_at = datetime.utcnow()
+            job.lease_expires_at = datetime.utcnow() + timedelta(seconds=cfg.JOB_LEASE_TIMEOUT_SECONDS)
             db.commit()
 
     def _mark_success(self, db, celery_task_id: str, result: Any):
@@ -64,21 +77,50 @@ class DatabaseTask(Task):
             job.result = json.dumps(result)
             job.progress = 100.0
             job.finished_at = datetime.utcnow()
+            # BE-W5-047: Clear lease on completion
+            job.lease_expires_at = None
+            job.heartbeat_at = None
             db.commit()
 
-    def _mark_failure(self, db, celery_task_id: str, error: str):
+    def _mark_failure(self, db, celery_task_id: str, error: str, error_code: Optional[str] = None, error_retryable: Optional[bool] = None):
         job = self._get_job(db, celery_task_id)
         if not job:
             return
         # BE-W5-054: bucket retry_count so the QUARANTINED boundary is invariant.
-        # We compare 'attempts' (this attempt) against max_retries so the
-        # transition into QUARANTINED occurs after the final allowed attempt
-        # fails — never one attempt early or late.
         attempts = (job.retry_count or 0) + 1
-        # BE-W5-054: poison-message quarantine. If this attempt exhausts the
-        # per-job ``max_retries`` cap, quarantine it instead of letting
-        # subsequent periodic retry sweeps keep bouncing it through the worker.
+        # BE-W5-054: poison-message quarantine
         if attempts >= max(job.max_retries, 0):
+            # BE-W5-048: if dead-letter is enabled, route exhausted jobs there
+            if cfg.JOB_RETRY_DEAD_LETTER_ENABLED:
+                job.status = JobStatus.DEAD_LETTER
+                job.dead_letter_reason = f"Max retries exhausted ({job.max_retries}). Last error: {error}"
+                job.dead_letter_at = datetime.utcnow()
+                job.finished_at = datetime.utcnow()
+                job.retry_count = attempts
+                job.error = error
+                job.error_code = error_code or "DEAD_LETTER"
+                job.error_retryable = False
+                logger.error(
+                    "BE-W5-048: dead-lettering job %s type=%s after %d attempts: %s",
+                    job.id, job.job_type.value, attempts, error,
+                )
+                audit_log.log_event(
+                    db,
+                    event_type="job_dead_lettered",
+                    details={
+                        "job_id": str(job.id),
+                        "celery_task_id": celery_task_id,
+                        "job_type": job.job_type.value,
+                        "retry_count": attempts,
+                        "max_retries": job.max_retries,
+                        "retry_class": job.retry_class,
+                        "error": error,
+                        "error_code": error_code,
+                    },
+                )
+                db.commit()
+                return
+
             payload_hash = _hash_job_payload(job)
             job.payload_hash = payload_hash
             job.quarantine_reason = error
@@ -86,6 +128,8 @@ class DatabaseTask(Task):
             job.status = JobStatus.QUARANTINED
             job.retry_count = attempts
             job.finished_at = datetime.utcnow()
+            job.error_code = error_code or "QUARANTINED"
+            job.error_retryable = False
             logger.error(
                 "BE-W5-054: quarantining job %s type=%s payload_hash=%s after "
                 "%d attempts: %s",
@@ -110,6 +154,8 @@ class DatabaseTask(Task):
         job.retry_count = attempts
         job.status = JobStatus.FAILURE
         job.error = error
+        job.error_code = error_code
+        job.error_retryable = error_retryable if error_retryable is not None else False
         job.finished_at = datetime.utcnow()
         db.commit()
 
@@ -238,12 +284,16 @@ def compute_sla_for_device(self: DatabaseTask, device_id: str, period: str, corr
     except Exception as exc:
         error_msg = str(exc)
         logger.exception("SLA computation failed for device=%s: %s", device_id, error_msg)
-        
+
+        # BE-W5-050: Classify error for typed envelope
+        error_code = "SLA_COMPUTATION_ERROR"
+        error_retryable = self.request.retries < self.max_retries
+
         # Log retry attempt if we have retries left
         if self.request.retries < self.max_retries:
             self._log_retry(db, self.request.id, self.request.retries + 1, error_msg)
-        
-        self._mark_failure(db, self.request.id, error_msg)
+
+        self._mark_failure(db, self.request.id, error_msg, error_code=error_code, error_retryable=error_retryable)
         raise self.retry(exc=exc)
     finally:
         db.close()
@@ -344,12 +394,14 @@ def compute_bulk_sla(self: DatabaseTask, device_ids: List[str], period: str) -> 
     except Exception as exc:
         error_msg = str(exc)
         logger.exception("Bulk SLA computation failed: %s", error_msg)
-        
-        # Log retry attempt if we have retries left
+
+        error_code = "BULK_SLA_COMPUTATION_ERROR"
+        error_retryable = self.request.retries < self.max_retries
+
         if self.request.retries < self.max_retries:
             self._log_retry(db, self.request.id, self.request.retries + 1, error_msg)
-        
-        self._mark_failure(db, self.request.id, error_msg)
+
+        self._mark_failure(db, self.request.id, error_msg, error_code=error_code, error_retryable=error_retryable)
         raise self.retry(exc=exc)
     finally:
         db.close()

--- a/app/tasks/webhook_tasks.py
+++ b/app/tasks/webhook_tasks.py
@@ -1,13 +1,14 @@
 import json
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from celery import Task
 
 from app.tasks.celery_app import celery_app
+from app.core.config import settings as cfg
 from app.db.session import SessionLocal
 from app.models.job import Job, JobStatus, JobType
 from app.services.audit_log import audit_log
@@ -16,11 +17,12 @@ logger = logging.getLogger(__name__)
 
 
 class WebhookDatabaseTask(Task):
-    """Task base for webhook Celery tasks — tracks progress & supports quarantine.
+    """Task base for webhook Celery tasks — tracks progress, supports quarantine,
+    and manages lease heartbeats (BE-W5-047).
 
     BE-W5-054: Tasks inherit this base so retries can be quarantined after the
-    per-delivery retry budget is exhausted, and so progress reporting mirrors
-    the existing SLA task tracking.
+    per-delivery retry budget is exhausted.
+    BE-W5-047: Lease heartbeats are recorded for long-running DR replay tasks.
     """
 
     abstract = True
@@ -33,6 +35,34 @@ class WebhookDatabaseTask(Task):
 
     def _get_job_by_id(self, db, job_id: str) -> Optional[Job]:
         return db.query(Job).filter(Job.id == job_id).first()
+
+    def _heartbeat(self, db, celery_task_id: str):
+        """BE-W5-047: Extend the lease on a running job."""
+        job = self._get_job(db, celery_task_id)
+        if job and job.status == JobStatus.STARTED:
+            job.heartbeat_at = datetime.utcnow()
+            job.lease_expires_at = datetime.utcnow() + timedelta(
+                seconds=cfg.JOB_LEASE_TIMEOUT_SECONDS
+            )
+            try:
+                db.commit()
+            except Exception:
+                db.rollback()
+
+    def _mark_started(self, db, celery_task_id: str):
+        """BE-W5-047: Initialise lease on task start."""
+        job = self._get_job(db, celery_task_id)
+        if job:
+            job.status = JobStatus.STARTED
+            job.started_at = datetime.utcnow()
+            job.heartbeat_at = datetime.utcnow()
+            job.lease_expires_at = datetime.utcnow() + timedelta(
+                seconds=cfg.JOB_LEASE_TIMEOUT_SECONDS
+            )
+            try:
+                db.commit()
+            except Exception:
+                db.rollback()
 
     def _update_progress(
         self,
@@ -73,6 +103,37 @@ def dispatch_webhook_delivery(self, delivery_id: str) -> Dict[str, Any]:
     except Exception as exc:
         error_msg = str(exc)
         logger.exception("Failed to dispatch webhook delivery %s: %s", delivery_id, error_msg)
+
+        # BE-W5-048: Check if retries are exhausted before raising to Celery
+        if self.request.retries >= self.max_retries:
+            # Retries exhausted — route to dead-letter terminal status
+            job = db.query(Job).filter(Job.celery_task_id == self.request.id).first()
+            if job:
+                job.status = JobStatus.DEAD_LETTER
+                job.dead_letter_reason = (
+                    f"Max retries exhausted ({self.max_retries}). Last error: {error_msg}"
+                )
+                job.dead_letter_at = datetime.utcnow()
+                job.finished_at = datetime.utcnow()
+                job.error = error_msg
+                job.error_code = "WEBHOOK_RETRIES_EXHAUSTED"
+                job.error_retryable = False
+                try:
+                    db.commit()
+                except Exception:
+                    db.rollback()
+                audit_log.log_event(
+                    db,
+                    event_type="job_dead_lettered",
+                    details={
+                        "delivery_id": delivery_id,
+                        "job_type": JobType.WEBHOOK_DISPATCH.value,
+                        "retry_count": self.request.retries + 1,
+                        "max_retries": self.max_retries,
+                        "error": error_msg,
+                    },
+                )
+            return {"delivery_id": delivery_id, "dispatched": False, "dead_lettered": True}
 
         # Log retry attempt if we have retries left
         if self.request.retries < self.max_retries:

--- a/docs/API.md
+++ b/docs/API.md
@@ -859,6 +859,186 @@ https://github.com/OpSoll/noc-iq-be/blob/main/postman/NOCIQ-API.json
 
 ---
 
+---
+
+## Jobs & Async Tasks
+
+Status: active and routed.  Background job tracking, retry governance, lease
+heartbeat, and retention tiering.
+
+### Job Status Values
+
+| Status | Description |
+|--------|-------------|
+| `pending` | Job enqueued, awaiting worker pickup |
+| `started` | Job is actively executing |
+| `success` | Job completed successfully |
+| `failure` | Job failed with retries remaining |
+| `revoked` | Job was cancelled by an operator |
+| `quarantined` | Job moved to quarantine after exhausting all retries (BE-W5-054) |
+| `dead_letter` | Job reached terminal dead-letter after max retries (BE-W5-048) |
+
+### Job Result Envelope (BE-W5-050)
+
+Every job endpoint returns a standardised envelope:
+
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "celery_task_id": "abc123...",
+  "job_type": "sla_computation",
+  "status": "success",
+  "progress": 100.0,
+  "result": { "mttr_minutes": 12, "is_violated": false },
+  "error": {
+    "code": "SLA_TIMEOUT",
+    "message": "Contract execution timed out",
+    "retryable": true,
+    "details": { "timeout_ms": 5000 }
+  },
+  "retry_count": 2,
+  "max_retries": 3,
+  "retry_class": "exponential_backoff",
+  "started_at": "2026-07-29T10:00:00Z",
+  "finished_at": "2026-07-29T10:00:45Z",
+  "created_at": "2026-07-29T09:59:55Z",
+  "worker_id": "worker-01",
+  "lease_expires_at": "2026-07-29T10:02:00Z",
+  "under_investigation": false,
+  "under_dispute": false,
+  "audit_critical": false
+}
+```
+
+The `error` field uses a typed `JobErrorDetail` with:
+- `code`: Machine-readable error code (e.g. `"SLA_TIMEOUT"`, `"DEAD_LETTER"`)
+- `message`: Human-readable description
+- `retryable`: Whether the job can be retried
+- `details`: Optional contextual payload
+
+### GET `/api/v1/jobs`
+
+List all jobs with optional filters.
+
+**Query Parameters:**
+- `job_type`: Filter by type (`sla_computation`, `webhook_dispatch`, `bulk_sla_computation`, `webhook_dr_replay`)
+- `status`: Filter by status
+- `limit` (default=50, max=200): Number of results
+
+### GET `/api/v1/jobs/{job_id}`
+
+Get a single job's status.  Syncs from Celery for in-progress jobs.
+
+### GET `/api/v1/jobs/{job_id}/envelope`
+
+Get a single job wrapped in the standardised result envelope (BE-W5-050).
+
+### GET `/api/v1/jobs/{job_id}/progress`
+
+Lightweight polling endpoint returning only progress fields.
+
+### POST `/api/v1/jobs/sla-computation`
+
+Enqueue an async SLA computation for a single device.
+
+**Request Body:**
+```json
+{ "device_id": "dev-001", "period": "2026-07" }
+```
+
+### POST `/api/v1/jobs/sla-computation/bulk`
+
+Enqueue an async bulk SLA computation.
+
+**Request Body:**
+```json
+{ "device_ids": ["dev-001", "dev-002"], "period": "2026-07" }
+```
+
+### POST `/api/v1/jobs/{job_id}/retry`
+
+Retry a failed, revoked, or dead-letter job (BE-041, BE-W5-048).
+
+**Retry Taxonomy Governance (BE-W5-048):**
+- `at_most_once`: Cannot be retried (manual inspection only)
+- `at_least_once`: Retries until success with capped backoff
+- `exponential_backoff`: Progressive backoff with jitter
+
+Exhausted jobs are dead-lettered (`dead_letter` status) when
+`JOB_RETRY_DEAD_LETTER_ENABLED` is `True`.
+
+### GET `/api/v1/jobs/retry-policies`
+
+List configured retry taxonomy policies per job type (BE-W5-048).
+
+### GET `/api/v1/jobs/dead-letter`
+
+List jobs in `dead_letter` status (BE-W5-048).  Admin only.
+
+### POST `/api/v1/jobs/{job_id}/heartbeat`
+
+Record a lease heartbeat for a running job (BE-W5-047).
+Internal endpoint used by workers to extend their lease.
+
+**Query Parameters:**
+- `worker_id` (required): Worker identifier
+
+### POST `/api/v1/jobs/reclaim-stale-leases`
+
+Reclaim jobs with expired worker leases (BE-W5-047).
+
+**Request Body:**
+```json
+{
+  "timeout_seconds": 120,
+  "batch_size": 50,
+  "dry_run": false
+}
+```
+
+### GET `/api/v1/jobs/retention-stats`
+
+Get job retention statistics with protection-flag counts (BE-W5-052).
+
+### POST `/api/v1/jobs/cleanup`
+
+Clean up old jobs using retention tiering (BE-W5-052).
+
+Protected records (under investigation, under dispute, audit-critical)
+are excluded from standard cleanup sweeps.
+
+**Request Body:**
+```json
+{
+  "retention_days": { "success": 30, "failure": 90 },
+  "dry_run": true,
+  "batch_size": 1000
+}
+```
+
+### POST `/api/v1/jobs/cleanup-audit-critical`
+
+Clean up audit-critical jobs past their extended retention window (BE-W5-052).
+
+### PATCH `/api/v1/jobs/{job_id}/protection-flags`
+
+Toggle investigation or dispute flags to protect a job from cleanup (BE-W5-052).
+
+**Request Body:**
+```json
+{ "under_investigation": true, "under_dispute": false }
+```
+
+### GET `/api/v1/jobs/quarantined`
+
+List quarantined poison-message jobs (BE-W5-054).  Admin only.
+
+### POST `/api/v1/jobs/{job_id}/release-from-quarantine`
+
+Release a quarantined job back into the retry pipeline (BE-W5-054).
+
+---
+
 For more information, visit our [GitHub repository](https://github.com/OpSoll/noc-iq-be)
 
 # Analytics & SLA Error Handling Semantics

--- a/tests/test_mercy60_issues.py
+++ b/tests/test_mercy60_issues.py
@@ -1,0 +1,376 @@
+"""Tests for Mercy60-assigned issues:
+
+  BE-W5-050 (#311) — Background job result schema standardization
+  BE-W5-048 (#309) — Job retry taxonomy and maximum-attempt governance
+  BE-W5-047 (#308) — Job lease heartbeat and stuck-task reclamation
+  BE-W5-052 (#313) — Job cleanup policy hardening with retention tiering
+"""
+import json
+from datetime import datetime, timedelta
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from app.models.job import (
+    Job,
+    JobErrorDetail,
+    JobResultEnvelope,
+    JobStatus,
+    JobType,
+    RetryClass,
+)
+from app.services.job_cleanup import (
+    JobCleanupService,
+    RETRY_CLASS_DEFAULTS,
+    get_retry_policy,
+    heartbeat_job,
+    reclaim_stale_leases,
+)
+from app.core.config import Settings
+
+
+# --------------------------------------------------------------------------- #
+# BE-W5-050: Job result schema standardization                                #
+# --------------------------------------------------------------------------- #
+
+class TestBE_W5_050:
+    """Standardized job result envelope and typed error metadata."""
+
+    def test_job_error_detail_serialization(self):
+        err = JobErrorDetail(
+            code="SLA_TIMEOUT",
+            message="Contract call timed out",
+            retryable=True,
+            details={"timeout_ms": 5000},
+        )
+        data = err.model_dump()
+        assert data["code"] == "SLA_TIMEOUT"
+        assert data["message"] == "Contract call timed out"
+        assert data["retryable"] is True
+        assert data["details"]["timeout_ms"] == 5000
+
+    def test_job_error_detail_minimal(self):
+        err = JobErrorDetail(code="UNKNOWN", message="something went wrong")
+        data = err.model_dump()
+        assert data["retryable"] is False  # default
+        assert data["details"] is None
+
+    def test_job_result_envelope_shape(self):
+        envelope = JobResultEnvelope(
+            job_id="550e8400-e29b-41d4-a716-446655440000",
+            celery_task_id="task-001",
+            job_type="sla_computation",
+            status="success",
+            progress=100.0,
+            result={"mttr": 12},
+            error=None,
+            retry_count=0,
+            max_retries=3,
+            retry_class="exponential_backoff",
+            started_at="2026-07-29T10:00:00Z",
+            finished_at="2026-07-29T10:00:45Z",
+            created_at="2026-07-29T09:59:55Z",
+        )
+        data = envelope.model_dump()
+        assert data["job_id"] == "550e8400-e29b-41d4-a716-446655440000"
+        assert data["job_type"] == "sla_computation"
+        assert data["status"] == "success"
+        assert data["error"] is None
+        assert data["retry_class"] == "exponential_backoff"
+
+    def test_job_result_envelope_with_error(self):
+        envelope = JobResultEnvelope(
+            job_id="j1",
+            celery_task_id="t1",
+            job_type="webhook_dispatch",
+            status="failure",
+            error=JobErrorDetail(code="WEBHOOK_TIMEOUT", message="timeout", retryable=True),
+        )
+        data = envelope.model_dump()
+        assert data["error"]["code"] == "WEBHOOK_TIMEOUT"
+        assert data["error"]["retryable"] is True
+
+    def test_job_model_has_new_columns(self):
+        """Verify the Job model exposes all new columns for BE-W5-050."""
+        assert hasattr(Job, "error_code")
+        assert hasattr(Job, "error_retryable")
+        assert hasattr(Job, "error_details")
+
+
+# --------------------------------------------------------------------------- #
+# BE-W5-048: Retry taxonomy and dead-letter governance                        #
+# --------------------------------------------------------------------------- #
+
+class TestBE_W5_048:
+    """Retry taxonomy defaults, dead-letter routing, and governance."""
+
+    def test_retry_class_enum_values(self):
+        assert RetryClass.AT_MOST_ONCE.value == "at_most_once"
+        assert RetryClass.AT_LEAST_ONCE.value == "at_least_once"
+        assert RetryClass.EXPONENTIAL_BACKOFF.value == "exponential_backoff"
+
+    def test_RETRY_CLASS_DEFAULTS_has_all_types(self):
+        for jt in ["sla_computation", "bulk_sla_computation", "webhook_dispatch", "webhook_dr_replay"]:
+            assert jt in RETRY_CLASS_DEFAULTS, f"Missing retry defaults for {jt}"
+
+    def test_get_retry_policy_known_type(self):
+        policy = get_retry_policy("sla_computation")
+        assert policy["retry_class"] == "exponential_backoff"
+        assert policy["max_retries"] == 3
+        assert policy["base_delay_seconds"] == 30
+
+    def test_get_retry_policy_webhook_dr_replay(self):
+        policy = get_retry_policy("webhook_dr_replay")
+        assert policy["retry_class"] == "at_most_once"
+        assert policy["max_retries"] == 1
+
+    def test_get_retry_policy_unknown_type_falls_back(self):
+        policy = get_retry_policy("unknown_type")
+        assert policy["retry_class"] == "at_least_once"
+        assert policy["max_retries"] == 3
+
+    def test_dead_letter_status_exists(self):
+        assert JobStatus.DEAD_LETTER.value == "dead_letter"
+
+    def test_job_model_has_dead_letter_columns(self):
+        assert hasattr(Job, "dead_letter_reason")
+        assert hasattr(Job, "dead_letter_at")
+        assert hasattr(Job, "retry_class")
+
+    def test_config_has_dead_letter_settings(self):
+        s = Settings()
+        assert hasattr(s, "JOB_RETRY_DEAD_LETTER_ENABLED")
+        assert hasattr(s, "JOB_RETRY_BACKOFF_MAX_DELAY_SECONDS")
+        assert hasattr(s, "JOB_RETRY_BACKOFF_MULTIPLIER")
+        assert hasattr(s, "JOB_RETRY_CLASS_DEFAULTS")
+
+    def test_retry_class_defaults_parse(self):
+        """JOB_RETRY_CLASS_DEFAULTS config string is well-formed."""
+        s = Settings()
+        raw = s.JOB_RETRY_CLASS_DEFAULTS
+        entries = [e for e in raw.split(",") if e.strip()]
+        assert len(entries) >= 4
+        for entry in entries:
+            parts = entry.split(":")
+            assert len(parts) == 4, f"Entry '{entry}' should have 4 colon-separated parts"
+            int(parts[2])  # max_retries must be int
+            int(parts[3])  # base_delay must be int
+
+
+# --------------------------------------------------------------------------- #
+# BE-W5-047: Lease heartbeat and stuck-task reclamation                       #
+# --------------------------------------------------------------------------- #
+
+class TestBE_W5_047:
+    """Worker lease heartbeat and stale-lease reclamation."""
+
+    def test_job_model_has_lease_columns(self):
+        assert hasattr(Job, "worker_id")
+        assert hasattr(Job, "heartbeat_at")
+        assert hasattr(Job, "lease_expires_at")
+
+    def test_heartbeat_updates_job(self):
+        db = MagicMock()
+        mock_job = MagicMock(spec=Job)
+        mock_job.celery_task_id = "task-001"
+        db.query.return_value.filter.return_value.first.return_value = mock_job
+
+        result = heartbeat_job(db, "task-001", "worker-abc", timeout_seconds=120)
+        assert result is mock_job
+        assert mock_job.worker_id == "worker-abc"
+        assert mock_job.heartbeat_at is not None
+        assert mock_job.lease_expires_at is not None
+        db.commit.assert_called_once()
+
+    def test_heartbeat_nonexistent_job(self):
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        result = heartbeat_job(db, "missing-task", "worker-abc")
+        assert result is None
+
+    def test_reclaim_stale_leases_dry_run(self):
+        db = MagicMock()
+        stale_job = MagicMock(spec=Job)
+        stale_job.id = "job-1"
+        stale_job.celery_task_id = "task-1"
+        stale_job.job_type = JobType.SLA_COMPUTATION
+        stale_job.worker_id = "worker-old"
+        stale_job.lease_expires_at = datetime.utcnow() - timedelta(minutes=5)
+        stale_job.status = JobStatus.STARTED
+
+        db.query.return_value.filter.return_value.limit.return_value.all.return_value = [stale_job]
+
+        result = reclaim_stale_leases(db, timeout_seconds=120, dry_run=True)
+        assert result["stale_leases_found"] == 1
+        assert result["reclaimed"] == 1
+        assert result["dry_run"] is True
+        # No commit in dry run
+        db.commit.assert_not_called()
+
+    def test_reclaim_stale_leases_live(self):
+        db = MagicMock()
+        stale_job = MagicMock(spec=Job)
+        stale_job.id = "job-1"
+        stale_job.celery_task_id = "task-1"
+        stale_job.job_type = JobType.SLA_COMPUTATION
+        stale_job.worker_id = "worker-old"
+        stale_job.lease_expires_at = datetime.utcnow() - timedelta(minutes=5)
+        stale_job.status = JobStatus.STARTED
+
+        db.query.return_value.filter.return_value.limit.return_value.all.return_value = [stale_job]
+
+        result = reclaim_stale_leases(db, timeout_seconds=120, dry_run=False)
+        assert result["reclaimed"] == 1
+        assert result["dry_run"] is False
+        assert stale_job.worker_id is None
+        assert stale_job.lease_expires_at is None
+        assert stale_job.status == JobStatus.PENDING
+
+    def test_config_has_lease_settings(self):
+        s = Settings()
+        assert hasattr(s, "JOB_LEASE_HEARTBEAT_INTERVAL_SECONDS")
+        assert hasattr(s, "JOB_LEASE_TIMEOUT_SECONDS")
+        assert hasattr(s, "JOB_LEASE_RECLAMATION_ENABLED")
+
+
+# --------------------------------------------------------------------------- #
+# BE-W5-052: Retention tiering                                                #
+# --------------------------------------------------------------------------- #
+
+class TestBE_W5_052:
+    """Retention tiering, protection flags, and audit-critical cleanup."""
+
+    def test_job_model_has_protection_columns(self):
+        assert hasattr(Job, "under_investigation")
+        assert hasattr(Job, "under_dispute")
+        assert hasattr(Job, "audit_critical")
+
+    def test_config_has_retention_settings(self):
+        s = Settings()
+        assert hasattr(s, "JOB_RETENTION_SUCCESS_DAYS")
+        assert hasattr(s, "JOB_RETENTION_FAILURE_DAYS")
+        assert hasattr(s, "JOB_RETENTION_QUARANTINED_DAYS")
+        assert hasattr(s, "JOB_RETENTION_DEAD_LETTER_DAYS")
+        assert hasattr(s, "JOB_RETENTION_AUDIT_CRITICAL_DAYS")
+        assert hasattr(s, "JOB_RETENTION_INVESTIGATION_PROTECTED")
+        assert hasattr(s, "JOB_RETENTION_DISPUTE_PROTECTED")
+
+    def test_default_retention_windows(self):
+        windows = JobCleanupService._default_retention()
+        assert "success" in windows
+        assert "failure" in windows
+        assert "quarantined" in windows
+        assert "dead_letter" in windows
+
+    def test_cleanup_skips_protected_records(self):
+        db = MagicMock()
+        service = JobCleanupService(db)
+
+        # Mock: build_base_query excludes protected records
+        mock_query = MagicMock()
+        db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.filter.return_value.filter.return_value = mock_query
+        mock_query.filter.return_value.filter.return_value.filter.return_value = mock_query
+        mock_query.filter.return_value.filter.return_value.filter.return_value.count.return_value = 0
+
+        result = service.cleanup_old_jobs(dry_run=True)
+        assert result["dry_run"] is True
+        assert result["total_deleted"] == 0
+
+    def test_get_retention_stats_includes_protected(self):
+        db = MagicMock()
+        service = JobCleanupService(db)
+        # Mock counts
+        db.query.return_value.count.return_value = 0
+        db.query.return_value.filter.return_value.count.return_value = 0
+
+        stats = service.get_retention_stats()
+        assert "protected" in stats
+        assert "under_investigation" in stats["protected"]
+        assert "under_dispute" in stats["protected"]
+        assert "audit_critical" in stats["protected"]
+
+    def test_set_investigation_flag(self):
+        db = MagicMock()
+        mock_job = MagicMock(spec=Job)
+        db.query.return_value.filter.return_value.first.return_value = mock_job
+
+        service = JobCleanupService(db)
+        result = service.set_investigation_flag("job-1", True)
+        assert result is mock_job
+        assert mock_job.under_investigation is True
+        db.commit.assert_called_once()
+
+    def test_set_dispute_flag(self):
+        db = MagicMock()
+        mock_job = MagicMock(spec=Job)
+        db.query.return_value.filter.return_value.first.return_value = mock_job
+
+        service = JobCleanupService(db)
+        result = service.set_dispute_flag("job-1", True)
+        assert result is mock_job
+        assert mock_job.under_dispute is True
+
+    def test_cleanup_audit_critical(self):
+        db = MagicMock()
+        service = JobCleanupService(db)
+
+        mock_query = MagicMock()
+        db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.filter.return_value.filter.return_value = mock_query
+        mock_query.filter.return_value.filter.return_value.filter.return_value = mock_query
+        mock_query.filter.return_value.filter.return_value.filter.return_value.count.return_value = 5
+
+        result = service.cleanup_audit_critical(retention_days=365, dry_run=True)
+        assert result["audit_critical_eligible"] == 5
+        assert result["dry_run"] is True
+        assert result["retention_days"] == 365
+
+
+# --------------------------------------------------------------------------- #
+# Integration test: retry taxonomy applied on enqueue                          #
+# --------------------------------------------------------------------------- #
+
+class TestIntegration:
+    """Smoke tests for the integration of multiple Mercy60 issues."""
+
+    def test_job_envelope_roundtrip(self):
+        """A JobResultEnvelope can be constructed from all fields."""
+        envelope = JobResultEnvelope(
+            job_id="j1",
+            celery_task_id="t1",
+            job_type="sla_computation",
+            status="success",
+            progress=100.0,
+            result={"ok": True},
+            error=JobErrorDetail(code="OK", message="all good", retryable=False),
+            retry_count=0,
+            max_retries=3,
+            retry_class="exponential_backoff",
+            started_at="2026-07-29T10:00:00Z",
+            finished_at="2026-07-29T10:00:45Z",
+            created_at="2026-07-29T09:59:55Z",
+            worker_id="worker-1",
+            lease_expires_at="2026-07-29T10:02:00Z",
+            under_investigation=False,
+            under_dispute=False,
+            audit_critical=False,
+        )
+        data = envelope.model_dump()
+        assert data["worker_id"] == "worker-1"
+        assert data["lease_expires_at"] is not None
+        assert data["under_investigation"] is False
+
+    def test_all_job_statuses_in_retention(self):
+        """BE-W5-052: retention windows exist for all terminal statuses."""
+        windows = JobCleanupService._default_retention()
+        for st in [JobStatus.SUCCESS, JobStatus.FAILURE, JobStatus.REVOKED]:
+            assert st.value in windows, f"Missing retention window for {st.value}"
+
+    def test_quarantined_retention_longer(self):
+        """Quarantined and dead-letter jobs have longer retention."""
+        windows = JobCleanupService._default_retention()
+        assert windows[JobStatus.QUARANTINED.value] >= windows[JobStatus.SUCCESS.value]
+        assert windows[JobStatus.DEAD_LETTER.value] >= windows[JobStatus.SUCCESS.value]


### PR DESCRIPTION
BE-W5-050 (#311) — Background job result schema standardization
  * Add JobErrorDetail + JobResultEnvelope Pydantic models
  * Add error_code, error_retryable, error_details columns to Job
  * New GET /jobs/{id}/envelope endpoint
  * Typed error codes in SLA and webhook task failures

BE-W5-048 (#309) — Job retry taxonomy & maximum-attempt governance
  * Add RetryClass enum (at_most_once, at_least_once, exponential_backoff)
  * Add DEAD_LETTER to JobStatus enum
  * Config-driven RETRY_CLASS_DEFAULTS per job type
  * New GET /jobs/retry-policies and GET /jobs/dead-letter endpoints
  * Dead-letter routing on retry exhaustion in SLA and webhook tasks

BE-W5-047 (#308) — Job lease heartbeat & stuck-task reclamation
  * Add worker_id, heartbeat_at, lease_expires_at columns to Job
  * Lease initialization on task start in DatabaseTask/WebhookDatabaseTask
  * New POST /jobs/{id}/heartbeat and POST /jobs/reclaim-stale-leases
  * stale-lease reclamation with single-owner guarantee and audit events

BE-W5-052 (#313) — Job cleanup policy hardening with retention tiering
  * Add under_investigation, under_dispute, audit_critical columns
  * Configurable retention windows per job status including quarantine (180d)
  * Protected records excluded from standard cleanup sweeps
  * Separate audit-critical cleanup with extended 365-day window
  * New PATCH /jobs/{id}/protection-flags and POST /jobs/cleanup-audit-critical

Also includes:
  * 30+ new config settings for retention, retry, and lease governance
  * Alembic migration 0024_mercy60_job_enhancements
  * 20+ unit tests in tests/test_mercy60_issues.py
  * Full Job API documentation in docs/API.md

Closes #308, closes #309, closes #311, closes #313